### PR TITLE
templatetags: fix active tag when unhandled exception raised

### DIFF
--- a/fpr/templatetags/active.py
+++ b/fpr/templatetags/active.py
@@ -5,7 +5,9 @@ register = Library()
 
 @register.simple_tag
 def active(request, pattern):
-    if request.path.startswith(pattern) and pattern != '/':
+    if not request:
+        return ''
+    elif request.path.startswith(pattern) and pattern != '/':
         return 'active'
     elif request.path == pattern == '/':
         return 'active'


### PR DESCRIPTION
If Django calls handle_uncaught_exception, the passed "request" object will be an empty string instead of a Request object.

See artefactual/archivematica#248.
