### PR TITLE
IDCommand: Don't display tool in MicroServiceChoice

### DIFF
--- a/fpr/models.py
+++ b/fpr/models.py
@@ -183,7 +183,7 @@ class IDCommand(VersionedModel, models.Model):
                 MicroServiceChoiceReplacementDic.objects.create(
                     id=str(uuid.uuid4()),
                     choiceavailableatlink_id=link,
-                    description=str(self),
+                    description=self.description,
                     replacementdic=replace,
                 )
 


### PR DESCRIPTION
When creating MicroServiceChoiceReplacementDic, use description and mode but not tool because it often has an outdated version.

The existing migrations in Archivematica will have to be modified to fix the pre-populated MicroServiceChoiceReplacementDic values.
