### PR TITLE
Migrations: Update IDTool versions

### DIFF
--- a/fpr/migrations/0005_update_tool_versions.py
+++ b/fpr/migrations/0005_update_tool_versions.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+def data_migration(apps, schema_editor):
+    IDTool = apps.get_model('fpr', 'IDTool')
+    IDTool.objects.filter(description='Fido', version='1.3.4').update(version='1.3.5')
+    IDTool.objects.filter(description='Siegfried', version='1.5.0').update(version='1.6.7')
+
+def reverse_migration(apps, schema_editor):
+    IDTool = apps.get_model('fpr', 'IDTool')
+    IDTool.objects.filter(description='Fido', version='1.3.5').update(version='1.3.4')
+    IDTool.objects.filter(description='Siegfried', version='1.6.7').update(version='1.5.0')
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('fpr', '0004_pronom_88'),
+    ]
+
+    operations = [
+        migrations.RunPython(data_migration, reverse_migration),
+    ]


### PR DESCRIPTION
Update FIDO & Siegfried versions in the FPR to match what will be installed.

The fpr-admin submodule commit in Archivematica will also have to be updated once this is merged.