### PR TITLE
Fix migration 0009_pronom_90

### DIFF
--- a/fpr/__init__.py
+++ b/fpr/__init__.py
@@ -8,4 +8,4 @@
 .. moduleauthor:: Justin Simpson <jsimpson@artefactual.com>
 """
 
-__version__ = '1.6.1'
+__version__ = '1.6.2'

--- a/fpr/migrations/pronom_90.json
+++ b/fpr/migrations/pronom_90.json
@@ -6,8 +6,7 @@
             "uuid": "d364de7c-f0b7-44b0-9adc-f5fd248b1c1b",
             "description": "Jamcracker Tracker Module"
         },
-        "model": "fpr.format",
-        "pk": 1134
+        "model": "fpr.format"
     },
     {
         "fields": {
@@ -16,8 +15,7 @@
             "uuid": "2af6d03e-8ea7-4dac-85d6-1b5915df2aa3",
             "description": "MagicaVoxel Vox format"
         },
-        "model": "fpr.format",
-        "pk": 1135
+        "model": "fpr.format"
     },
     {
         "fields": {
@@ -26,8 +24,7 @@
             "uuid": "127e36c4-444c-4154-a0fe-c07d318ce463",
             "description": "AutoCAD Design Web Format(DWFx)"
         },
-        "model": "fpr.format",
-        "pk": 1136
+        "model": "fpr.format"
     },
     {
         "fields": {
@@ -36,8 +33,7 @@
             "uuid": "ece58a86-4043-49ee-9c22-6def7fb031f0",
             "description": "3DS Max"
         },
-        "model": "fpr.format",
-        "pk": 1137
+        "model": "fpr.format"
     },
     {
         "fields": {
@@ -46,8 +42,7 @@
             "uuid": "55a92d49-8580-4b59-9fe2-9e374e00ea20",
             "description": "XML Property List"
         },
-        "model": "fpr.format",
-        "pk": 1138
+        "model": "fpr.format"
     },
     {
         "fields": {
@@ -56,8 +51,7 @@
             "uuid": "054000f0-21d3-4751-9bcd-1c25b924de49",
             "description": "AAE Sidecar Format"
         },
-        "model": "fpr.format",
-        "pk": 1139
+        "model": "fpr.format"
     },
     {
         "fields": {
@@ -66,8 +60,7 @@
             "uuid": "087b8246-28c3-4dc0-b3e4-84201071a63a",
             "description": "EazyDraw File Format"
         },
-        "model": "fpr.format",
-        "pk": 1140
+        "model": "fpr.format"
     },
     {
         "fields": {
@@ -76,8 +69,7 @@
             "uuid": "60b4ba50-a09c-40d6-8050-e1a15e57d998",
             "description": "iMovieProj File Format"
         },
-        "model": "fpr.format",
-        "pk": 1141
+        "model": "fpr.format"
     },
     {
         "fields": {
@@ -86,8 +78,7 @@
             "uuid": "8bd14439-6275-40d2-a748-d54bbf403128",
             "description": "NIB File Format"
         },
-        "model": "fpr.format",
-        "pk": 1142
+        "model": "fpr.format"
     },
     {
         "fields": {
@@ -96,8 +87,7 @@
             "uuid": "409f2b35-56ae-49cf-a889-438007f1b3e9",
             "description": "Binary Property List"
         },
-        "model": "fpr.format",
-        "pk": 1143
+        "model": "fpr.format"
     },
     {
         "fields": {
@@ -106,8 +96,7 @@
             "uuid": "e0dcd33d-7a2c-42ca-b419-27c1e7ace3d0",
             "description": "Valve Texture Format"
         },
-        "model": "fpr.format",
-        "pk": 1144
+        "model": "fpr.format"
     },
     {
         "fields": {
@@ -116,8 +105,7 @@
             "uuid": "a3475e7f-6352-4df4-a194-26d7309a57f3",
             "description": "Extensible Metadata Platform Format"
         },
-        "model": "fpr.format",
-        "pk": 1145
+        "model": "fpr.format"
     },
     {
         "fields": {
@@ -126,8 +114,7 @@
             "uuid": "77727be8-0352-4f37-bca5-c5df50bc2186",
             "description": "Microsoft OneNote Package File"
         },
-        "model": "fpr.format",
-        "pk": 1146
+        "model": "fpr.format"
     },
     {
         "fields": {
@@ -136,8 +123,7 @@
             "uuid": "93a143c7-cc2c-4d8d-a8fa-15b71b7b0803",
             "description": "ESRI ArcScene Document"
         },
-        "model": "fpr.format",
-        "pk": 1147
+        "model": "fpr.format"
     },
     {
         "fields": {
@@ -146,8 +132,7 @@
             "uuid": "58a9c328-ef34-4ef3-a740-93c102f35d2f",
             "description": "ESRI ArcGlobe Document"
         },
-        "model": "fpr.format",
-        "pk": 1148
+        "model": "fpr.format"
     },
     {
         "fields": {
@@ -156,8 +141,7 @@
             "uuid": "ee847e05-3008-4c25-8ff9-02ed987bcf86",
             "description": "ESRI File Geodatabase"
         },
-        "model": "fpr.format",
-        "pk": 1149
+        "model": "fpr.format"
     },
     {
         "fields": {
@@ -166,8 +150,7 @@
             "uuid": "bc531f94-3954-412e-8771-c7801b0a9bc7",
             "description": "SHA256 File"
         },
-        "model": "fpr.format",
-        "pk": 1150
+        "model": "fpr.format"
     },
     {
         "fields": {
@@ -176,8 +159,7 @@
             "uuid": "c87aedcc-d6ee-4914-bbd2-c7420d9059a1",
             "description": "SHA1 File"
         },
-        "model": "fpr.format",
-        "pk": 1151
+        "model": "fpr.format"
     },
     {
         "fields": {
@@ -186,8 +168,7 @@
             "uuid": "adabf2cc-ef12-4761-94f1-4eab337213ed",
             "description": "MD5 File"
         },
-        "model": "fpr.format",
-        "pk": 1152
+        "model": "fpr.format"
     },
     {
         "fields": {
@@ -196,8 +177,7 @@
             "uuid": "9b332b8c-c0dc-4845-8041-97fbb6b9e9c1",
             "description": "Jeffs Image Format"
         },
-        "model": "fpr.format",
-        "pk": 1153
+        "model": "fpr.format"
     },
     {
         "fields": {
@@ -206,8 +186,7 @@
             "uuid": "e9a74141-bee8-496b-9f64-2deacb436b32",
             "description": "Adobe Photoshop Large Document Format"
         },
-        "model": "fpr.format",
-        "pk": 1154
+        "model": "fpr.format"
     },
     {
         "fields": {
@@ -216,8 +195,7 @@
             "uuid": "c5294495-ecdc-4288-aa05-91e257a554ac",
             "description": "SPSS Portable Data Format"
         },
-        "model": "fpr.format",
-        "pk": 1155
+        "model": "fpr.format"
     },
     {
         "fields": {
@@ -226,8 +204,7 @@
             "uuid": "e98d4fdf-0f1f-4780-aea3-43439742ba00",
             "description": "OpenRaster Image Format"
         },
-        "model": "fpr.format",
-        "pk": 1156
+        "model": "fpr.format"
     },
     {
         "fields": {
@@ -236,8 +213,7 @@
             "uuid": "68616e71-8dd7-42f7-a1a9-42f1a95eea2f",
             "description": "Krita Document Format"
         },
-        "model": "fpr.format",
-        "pk": 1157
+        "model": "fpr.format"
     },
     {
         "fields": {
@@ -246,8 +222,7 @@
             "uuid": "f8a74cb2-3035-4359-9b86-33dc68809acc",
             "description": "TZX Format"
         },
-        "model": "fpr.format",
-        "pk": 1158
+        "model": "fpr.format"
     },
     {
         "fields": {
@@ -256,8 +231,7 @@
             "uuid": "2635bad5-e3ea-4e66-9b48-eb0d8031431b",
             "description": "OpenEXR"
         },
-        "model": "fpr.format",
-        "pk": 1159
+        "model": "fpr.format"
     },
     {
         "fields": {
@@ -266,8 +240,7 @@
             "uuid": "be5dc296-476c-4912-b0a2-b739f9f454e4",
             "description": "Nearly Raw Raster Data"
         },
-        "model": "fpr.format",
-        "pk": 1160
+        "model": "fpr.format"
     },
     {
         "fields": {
@@ -276,8 +249,7 @@
             "uuid": "2ee6e001-3a0c-46b5-bc71-3020d68d49c6",
             "description": "Digital Speech Standard"
         },
-        "model": "fpr.format",
-        "pk": 1161
+        "model": "fpr.format"
     },
     {
         "fields": {
@@ -286,8 +258,7 @@
             "uuid": "80bc31d1-4072-44f7-a9aa-993725f2e988",
             "description": "DSS Pro"
         },
-        "model": "fpr.format",
-        "pk": 1162
+        "model": "fpr.format"
     },
     {
         "fields": {
@@ -296,8 +267,7 @@
             "uuid": "0d23ca00-d4c0-48d1-a89c-f8115a55b516",
             "description": "FBX (Filmbox) Binary"
         },
-        "model": "fpr.format",
-        "pk": 1163
+        "model": "fpr.format"
     },
     {
         "fields": {
@@ -306,8 +276,7 @@
             "uuid": "95d5bc54-5141-4330-91f1-5d41d7f7a798",
             "description": "FBX (Filmbox) Text"
         },
-        "model": "fpr.format",
-        "pk": 1164
+        "model": "fpr.format"
     },
     {
         "fields": {
@@ -316,8 +285,7 @@
             "uuid": "f7a9ea14-d202-4b4b-905b-c7d08a0e235a",
             "description": "INTERLIS Transfer File 1"
         },
-        "model": "fpr.format",
-        "pk": 1165
+        "model": "fpr.format"
     },
     {
         "fields": {
@@ -326,8 +294,7 @@
             "uuid": "8a915c80-ae6a-4946-acf3-d7e43daa0919",
             "description": "Statistical Analysis System Catalog (Windows)"
         },
-        "model": "fpr.format",
-        "pk": 1166
+        "model": "fpr.format"
     },
     {
         "fields": {
@@ -336,8 +303,7 @@
             "uuid": "29eb9cb6-be9a-407a-8739-427001441dc7",
             "description": "Statistical Analysis System Catalog (Unix)"
         },
-        "model": "fpr.format",
-        "pk": 1167
+        "model": "fpr.format"
     },
     {
         "fields": {
@@ -346,8 +312,7 @@
             "uuid": "0812098b-c61f-493c-b5ad-5d699a94b2a1",
             "description": "Stata Data (DTA) Format"
         },
-        "model": "fpr.format",
-        "pk": 1168
+        "model": "fpr.format"
     },
     {
         "fields": {
@@ -356,8 +321,7 @@
             "uuid": "944e8d36-064d-4149-9ed2-3e95fc2b0aa8",
             "description": "Redcode RAW (R3D) Media File"
         },
-        "model": "fpr.format",
-        "pk": 1169
+        "model": "fpr.format"
     },
     {
         "fields": {
@@ -366,8 +330,7 @@
             "uuid": "74da938b-47fb-4db1-b9a9-0074667e53bc",
             "description": "Redcode Metadata (RMD) File"
         },
-        "model": "fpr.format",
-        "pk": 1170
+        "model": "fpr.format"
     },
     {
         "fields": {
@@ -376,8 +339,7 @@
             "uuid": "a876194c-49cc-47c9-bfa6-257b981c5736",
             "description": "DirectDraw Surface"
         },
-        "model": "fpr.format",
-        "pk": 1171
+        "model": "fpr.format"
     },
     {
         "fields": {
@@ -386,8 +348,7 @@
             "uuid": "2d77a10b-e519-447b-b89b-74f5794113ed",
             "description": "INTERLIS Transfer File 2.2"
         },
-        "model": "fpr.format",
-        "pk": 1173
+        "model": "fpr.format"
     },
     {
         "fields": {
@@ -403,8 +364,7 @@
             "pronom_id": "fmt/975",
             "description": "Jamcracker Module"
         },
-        "model": "fpr.formatversion",
-        "pk": 1487
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -420,8 +380,7 @@
             "pronom_id": "fmt/976",
             "description": "MagicaVoxel"
         },
-        "model": "fpr.formatversion",
-        "pk": 1488
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -437,8 +396,7 @@
             "pronom_id": "fmt/977",
             "description": "AutoCAD Design Web Format(DWFx)"
         },
-        "model": "fpr.formatversion",
-        "pk": 1489
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -454,8 +412,7 @@
             "pronom_id": "fmt/978",
             "description": "3DS Max"
         },
-        "model": "fpr.formatversion",
-        "pk": 1490
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -471,8 +428,7 @@
             "pronom_id": "fmt/979",
             "description": "XML Property List"
         },
-        "model": "fpr.formatversion",
-        "pk": 1491
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -488,8 +444,7 @@
             "pronom_id": "fmt/980",
             "description": "AAE Sidecar Format"
         },
-        "model": "fpr.formatversion",
-        "pk": 1492
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -505,8 +460,7 @@
             "pronom_id": "fmt/981",
             "description": "EazyDraw File Format"
         },
-        "model": "fpr.formatversion",
-        "pk": 1493
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -522,8 +476,7 @@
             "pronom_id": "fmt/982",
             "description": "iMovieProj File Format"
         },
-        "model": "fpr.formatversion",
-        "pk": 1494
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -539,8 +492,7 @@
             "pronom_id": "fmt/983",
             "description": "NIB File Format"
         },
-        "model": "fpr.formatversion",
-        "pk": 1495
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -556,8 +508,7 @@
             "pronom_id": "fmt/984",
             "description": "Binary Property List"
         },
-        "model": "fpr.formatversion",
-        "pk": 1496
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -573,8 +524,7 @@
             "pronom_id": "fmt/985",
             "description": "Valve Texture Format little endian"
         },
-        "model": "fpr.formatversion",
-        "pk": 1497
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -590,8 +540,7 @@
             "pronom_id": "fmt/986",
             "description": "XMP file format"
         },
-        "model": "fpr.formatversion",
-        "pk": 1498
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -607,8 +556,7 @@
             "pronom_id": "fmt/987",
             "description": "OneNote package file"
         },
-        "model": "fpr.formatversion",
-        "pk": 1499
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -624,8 +572,7 @@
             "pronom_id": "fmt/988",
             "description": "ESRI ArcScene Document"
         },
-        "model": "fpr.formatversion",
-        "pk": 1500
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -641,8 +588,7 @@
             "pronom_id": "fmt/989",
             "description": "ESRI ArcGlobe Document"
         },
-        "model": "fpr.formatversion",
-        "pk": 1501
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -658,8 +604,7 @@
             "pronom_id": "fmt/990",
             "description": "ESRI File Geodatabase"
         },
-        "model": "fpr.formatversion",
-        "pk": 1502
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -675,8 +620,7 @@
             "pronom_id": "fmt/991",
             "description": "SHA256 File"
         },
-        "model": "fpr.formatversion",
-        "pk": 1503
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -692,8 +636,7 @@
             "pronom_id": "fmt/992",
             "description": "SHA1 File"
         },
-        "model": "fpr.formatversion",
-        "pk": 1504
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -709,8 +652,7 @@
             "pronom_id": "fmt/993",
             "description": "MD5 File"
         },
-        "model": "fpr.formatversion",
-        "pk": 1505
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -726,8 +668,7 @@
             "pronom_id": "fmt/994",
             "description": "Jeffs Image Format"
         },
-        "model": "fpr.formatversion",
-        "pk": 1506
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -743,8 +684,7 @@
             "pronom_id": "fmt/995",
             "description": "SIARD (Software-Independent Archiving of Relational Databases)"
         },
-        "model": "fpr.formatversion",
-        "pk": 1507
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -760,8 +700,7 @@
             "pronom_id": "fmt/996",
             "description": "Adobe Photoshop PSB"
         },
-        "model": "fpr.formatversion",
-        "pk": 1508
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -777,8 +716,7 @@
             "pronom_id": "fmt/997",
             "description": "SPSS Portable"
         },
-        "model": "fpr.formatversion",
-        "pk": 1509
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -794,8 +732,7 @@
             "pronom_id": "fmt/998",
             "description": "OpenRaster Image Format"
         },
-        "model": "fpr.formatversion",
-        "pk": 1510
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -811,8 +748,7 @@
             "pronom_id": "fmt/999",
             "description": "Krita Document Format"
         },
-        "model": "fpr.formatversion",
-        "pk": 1511
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -828,8 +764,7 @@
             "pronom_id": "fmt/1000",
             "description": "TZX Tape"
         },
-        "model": "fpr.formatversion",
-        "pk": 1512
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -845,8 +780,7 @@
             "pronom_id": "fmt/1001",
             "description": "OpenEXR"
         },
-        "model": "fpr.formatversion",
-        "pk": 1513
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -862,8 +796,7 @@
             "pronom_id": "fmt/1002",
             "description": "NRRD 1"
         },
-        "model": "fpr.formatversion",
-        "pk": 1514
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -879,8 +812,7 @@
             "pronom_id": "fmt/1003",
             "description": "NRRD 2"
         },
-        "model": "fpr.formatversion",
-        "pk": 1515
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -896,8 +828,7 @@
             "pronom_id": "fmt/1004",
             "description": "NRRD 3"
         },
-        "model": "fpr.formatversion",
-        "pk": 1516
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -913,8 +844,7 @@
             "pronom_id": "fmt/1005",
             "description": "NRRD 4"
         },
-        "model": "fpr.formatversion",
-        "pk": 1517
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -930,8 +860,7 @@
             "pronom_id": "fmt/1006",
             "description": "NRRD 5"
         },
-        "model": "fpr.formatversion",
-        "pk": 1518
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -947,8 +876,7 @@
             "pronom_id": "fmt/1007",
             "description": "Digital Speech Standard"
         },
-        "model": "fpr.formatversion",
-        "pk": 1519
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -964,8 +892,7 @@
             "pronom_id": "fmt/1008",
             "description": "Digital Speech Standard DSS Pro"
         },
-        "model": "fpr.formatversion",
-        "pk": 1520
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -981,8 +908,7 @@
             "pronom_id": "fmt/1009",
             "description": "FBX Binary"
         },
-        "model": "fpr.formatversion",
-        "pk": 1521
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -998,8 +924,7 @@
             "pronom_id": "fmt/1010",
             "description": "FBX Text"
         },
-        "model": "fpr.formatversion",
-        "pk": 1522
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -1015,8 +940,7 @@
             "pronom_id": "fmt/1011",
             "description": "Interlis transfer file 2.2 a"
         },
-        "model": "fpr.formatversion",
-        "pk": 1523
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -1032,8 +956,7 @@
             "pronom_id": "fmt/1012",
             "description": "INTERLIS model file 2.2"
         },
-        "model": "fpr.formatversion",
-        "pk": 1524
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -1049,8 +972,7 @@
             "pronom_id": "fmt/1013",
             "description": "INTERLIS transfer file 1"
         },
-        "model": "fpr.formatversion",
-        "pk": 1525
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -1066,8 +988,7 @@
             "pronom_id": "fmt/1014",
             "description": "INTERLIS model file 1"
         },
-        "model": "fpr.formatversion",
-        "pk": 1526
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -1083,8 +1004,7 @@
             "pronom_id": "fmt/1015",
             "description": "SAS Data (Windows) Generic"
         },
-        "model": "fpr.formatversion",
-        "pk": 1527
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -1100,8 +1020,7 @@
             "pronom_id": "fmt/1016",
             "description": "SAS Data (Unix) Generic"
         },
-        "model": "fpr.formatversion",
-        "pk": 1528
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -1117,8 +1036,7 @@
             "pronom_id": "fmt/1017",
             "description": "SAS Data (Windows) 8.2"
         },
-        "model": "fpr.formatversion",
-        "pk": 1529
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -1134,8 +1052,7 @@
             "pronom_id": "fmt/1018",
             "description": "SAS Data (Unix) 8.2"
         },
-        "model": "fpr.formatversion",
-        "pk": 1530
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -1151,8 +1068,7 @@
             "pronom_id": "fmt/1019",
             "description": "SAS Data (Windows) 9.2"
         },
-        "model": "fpr.formatversion",
-        "pk": 1531
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -1168,8 +1084,7 @@
             "pronom_id": "fmt/1020",
             "description": "SAS Data (Unix) 9.2"
         },
-        "model": "fpr.formatversion",
-        "pk": 1532
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -1185,8 +1100,7 @@
             "pronom_id": "fmt/1021",
             "description": "SAS Data (Windows) 9.3"
         },
-        "model": "fpr.formatversion",
-        "pk": 1533
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -1202,8 +1116,7 @@
             "pronom_id": "fmt/1022",
             "description": "SAS Data (Unix) 9.3"
         },
-        "model": "fpr.formatversion",
-        "pk": 1534
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -1219,8 +1132,7 @@
             "pronom_id": "fmt/1023",
             "description": "SAS Catalog (Windows) Generic"
         },
-        "model": "fpr.formatversion",
-        "pk": 1535
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -1236,8 +1148,7 @@
             "pronom_id": "fmt/1024",
             "description": "SAS Catalog (Unix) Generic"
         },
-        "model": "fpr.formatversion",
-        "pk": 1536
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -1253,8 +1164,7 @@
             "pronom_id": "fmt/1025",
             "description": "SAS Catalog (Windows) 9.2"
         },
-        "model": "fpr.formatversion",
-        "pk": 1537
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -1270,8 +1180,7 @@
             "pronom_id": "fmt/1026",
             "description": "SAS Catalog (Unix) 9.2"
         },
-        "model": "fpr.formatversion",
-        "pk": 1538
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -1287,8 +1196,7 @@
             "pronom_id": "fmt/1027",
             "description": "SAS Catalog (Windows) 9.3"
         },
-        "model": "fpr.formatversion",
-        "pk": 1539
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -1304,8 +1212,7 @@
             "pronom_id": "fmt/1028",
             "description": "SAS Catalog (Unix) 9.3"
         },
-        "model": "fpr.formatversion",
-        "pk": 1540
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -1321,8 +1228,7 @@
             "pronom_id": "fmt/1029",
             "description": "Stata DTA 104"
         },
-        "model": "fpr.formatversion",
-        "pk": 1541
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -1338,8 +1244,7 @@
             "pronom_id": "fmt/1030",
             "description": "Stata DTA 105"
         },
-        "model": "fpr.formatversion",
-        "pk": 1542
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -1355,8 +1260,7 @@
             "pronom_id": "fmt/1031",
             "description": "Stata DTA 110"
         },
-        "model": "fpr.formatversion",
-        "pk": 1543
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -1372,8 +1276,7 @@
             "pronom_id": "fmt/1032",
             "description": "Stata DTA 111"
         },
-        "model": "fpr.formatversion",
-        "pk": 1544
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -1389,8 +1292,7 @@
             "pronom_id": "fmt/1034",
             "description": "Stata DTA 114"
         },
-        "model": "fpr.formatversion",
-        "pk": 1545
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -1406,8 +1308,7 @@
             "pronom_id": "fmt/1033",
             "description": "Stata DTA 113"
         },
-        "model": "fpr.formatversion",
-        "pk": 1546
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -1423,8 +1324,7 @@
             "pronom_id": "fmt/1035",
             "description": "Stata DTA 115"
         },
-        "model": "fpr.formatversion",
-        "pk": 1547
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -1440,8 +1340,7 @@
             "pronom_id": "fmt/1036",
             "description": "Stata DTA 117"
         },
-        "model": "fpr.formatversion",
-        "pk": 1548
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -1457,8 +1356,7 @@
             "pronom_id": "fmt/1037",
             "description": "Stata DTA 118"
         },
-        "model": "fpr.formatversion",
-        "pk": 1549
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -1474,8 +1372,7 @@
             "pronom_id": "fmt/1038",
             "description": "R3D v2"
         },
-        "model": "fpr.formatversion",
-        "pk": 1550
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -1491,8 +1388,7 @@
             "pronom_id": "fmt/1039",
             "description": "Redcode Metadata"
         },
-        "model": "fpr.formatversion",
-        "pk": 1551
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -1508,43 +1404,7 @@
             "pronom_id": "fmt/1040",
             "description": "DirectDraw Surface"
         },
-        "model": "fpr.formatversion",
-        "pk": 1552
-    },
-    {
-        "fields": {
-            "replaces": "3bd47271-a3fa-4627-be97-9f7f69ddeefd",
-            "uuid": "7c2b65c7-6cea-4f81-9f3b-53375efc5bee",
-            "lastmodified": "2017-06-29T19:57:26.030Z",
-            "tool": "efa8474a-8526-48c3-8279-e5a76bdc0995",
-            "description": "Using default thumbnail",
-            "enabled": true,
-            "event_detail_command": null,
-            "output_location": "%outputDirectory%%postfix%.jpg",
-            "command_usage": "normalization",
-            "verification_command": "ef3ea000-0c3c-4cae-adc2-aa2a6ccbffce",
-            "command": "\nimport argparse\nimport sys\n\n# http://i.imgur.com/ijwSkff.jpg\nDEFAULT_THUMBNAIL = \"\"\"\n/9j/2wBDAAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEB\nAQEBAQEBAQEBAQEBAQH/2wBDAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEB\nAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQH/wAARCAAwADADASIAAhEBAxEB/8QAHAABAQACAgMA\nAAAAAAAAAAAACAAFCQEKAwQG/8QANBAAAAUDAgIFCwUAAAAAAAAAAQMEBQYAAgcICRESExQ5eLcV\nGSExV1iVmMHS1xZScYWn/8QAFgEBAQEAAAAAAAAAAAAAAAAAAAEC/8QAKBEAAgADBgUFAAAAAAAA\nAAAAAAECESESMVFhkcEiQUJxoVJystHS/9oADAMBAAIRAxEAPwDelul5RzWOsiAYeh2d8yYlgjdp\nmTZLBtxBOF+PVTjLXvKcmi7iufHJjLKXPye5mj7MQhQu5yxIymJVKhjKbTnl/vdQn13Pfvpa1vmN\nmf30vNzvtGIj3KWDx0n9F2gML13Pfvpa1vmNmf314znLPJBJp9+tLWwNhJRhtwW6jJkNw2l2jfcF\noCYADcIAPABEA4+sQD01nq9VcUaciWEkcnTGpVBRPSCNpfSmFX2F842gNwWc4hzCACIW8RABH0UA\nxdv3cZl2K2rHuPNW85dpbjLIrexrYhqAmLkscHTGsslRFi+yIZZkj48Ozu6QV6VKRvbMivKm0uBv\nSq9reDUuNFrVZivsa10WSpLlNjhDVBXjT4dJWxsjLVHFR9kua1qNyKbW5Mg6yY3AxKxKAy5PapAm\n+43oLuXlPvEsDR3HbLOsLKUyksm0c5BaXVQx4zxmom+OnWTOVy2UQ6Mx56g8SGAqHDqKW2SxxQfL\nLXOJ86VrugaBtURZrPeYisizHj2TWK1B8Tud9oxEe5SweOk/ou0otzvtGIj3KWDx0n9F2qCqqqoC\npC7VicpPuS5UEouwvrGkZ5PM5LQt5zByliEq6+7gAcbhAq0BuH0iAAHqAKPVI3a07SPJfc+efFjF\nFZivg9z+MRVdF23RldzvtGIj3KWDx0n9F2tru4Lt+ah9ROf4VnnT9P8AEjGvb8PW4ik0fysErbiC\nEjXNHmZNrwyuMXj8sFzNdTpGqRL0S1AyeRbWNIemWPnl5QQxC7zWe5H7TNH4f3OWPricarbXS3mr\nO8SfgSzS12TDnVSM81nuSe0zR/8AGcr/AImq81nuSe0zR/8AGcr/AImqWn6ItYP0JLFefoOdIzaz\nHjuSZND9uj94D/V8TXfWuB2styQfVk7SAH8PGVvriUaY+3ht4ahNNeoTIef8/wCQ8UyBxkGKQxdH\no9i79TuKe9O4yaNSNxdXVxkcah1zX5LuhyBMhQpkD/e9Xv7goUODEWxpEj1Ktw8LUnOtnBqSk3Wv\na+ook6pzWeKfNZH/2Q==\"\"\"\n\ndef main(target):\n    with open(target, 'w+b') as f:\n        f.write(DEFAULT_THUMBNAIL.decode('base64'))\n\nif __name__ == '__main__':\n    parser = argparse.ArgumentParser()\n    parser.add_argument('--output-location', required=True)\n    args, _ = parser.parse_known_args()\n\n    sys.exit(main(args.output_location))\n",
-            "output_format": "ffb55e9a-29f1-4276-a9a5-5ef813229b79",
-            "script_type": "pythonScript"
-        },
-        "model": "fpr.fpcommand",
-        "pk": 41
-    },
-    {
-        "fields": {
-            "count_not_okay": 0,
-            "replaces": "b0613a6c-943f-42fa-a0da-9c292eb81d38",
-            "count_attempts": 0,
-            "uuid": "3a19f9a3-c5d5-4934-9286-13b3ad6c24d3",
-            "format": "0ab4cd40-90e7-4d75-b294-498177b3897d",
-            "lastmodified": "2017-06-29T19:57:26.036Z",
-            "enabled": true,
-            "command": "7c2b65c7-6cea-4f81-9f3b-53375efc5bee",
-            "purpose": "default_thumbnail",
-            "count_okay": 0
-        },
-        "model": "fpr.fprule",
-        "pk": 789
+        "model": "fpr.formatversion"
     },
     {
         "fields": {
@@ -1559,8 +1419,7 @@
             "purpose": "preservation",
             "count_okay": 0
         },
-        "model": "fpr.fprule",
-        "pk": 790
+        "model": "fpr.fprule"
     },
     {
         "fields": {
@@ -1575,8 +1434,7 @@
             "purpose": "access",
             "count_okay": 0
         },
-        "model": "fpr.fprule",
-        "pk": 791
+        "model": "fpr.fprule"
     },
     {
         "fields": {
@@ -1591,8 +1449,7 @@
             "purpose": "characterization",
             "count_okay": 0
         },
-        "model": "fpr.fprule",
-        "pk": 792
+        "model": "fpr.fprule"
     },
     {
         "fields": {
@@ -1607,8 +1464,7 @@
             "purpose": "characterization",
             "count_okay": 0
         },
-        "model": "fpr.fprule",
-        "pk": 793
+        "model": "fpr.fprule"
     },
     {
         "fields": {
@@ -1623,8 +1479,7 @@
             "purpose": "characterization",
             "count_okay": 0
         },
-        "model": "fpr.fprule",
-        "pk": 794
+        "model": "fpr.fprule"
     },
     {
         "fields": {
@@ -1639,8 +1494,7 @@
             "purpose": "characterization",
             "count_okay": 0
         },
-        "model": "fpr.fprule",
-        "pk": 795
+        "model": "fpr.fprule"
     },
     {
         "fields": {
@@ -1655,8 +1509,7 @@
             "purpose": "characterization",
             "count_okay": 0
         },
-        "model": "fpr.fprule",
-        "pk": 796
+        "model": "fpr.fprule"
     },
     {
         "fields": {
@@ -1671,8 +1524,7 @@
             "purpose": "characterization",
             "count_okay": 0
         },
-        "model": "fpr.fprule",
-        "pk": 797
+        "model": "fpr.fprule"
     },
     {
         "fields": {
@@ -1687,8 +1539,7 @@
             "purpose": "characterization",
             "count_okay": 0
         },
-        "model": "fpr.fprule",
-        "pk": 798
+        "model": "fpr.fprule"
     },
     {
         "fields": {
@@ -1703,8 +1554,7 @@
             "purpose": "characterization",
             "count_okay": 0
         },
-        "model": "fpr.fprule",
-        "pk": 799
+        "model": "fpr.fprule"
     },
     {
         "fields": {
@@ -1719,8 +1569,7 @@
             "purpose": "characterization",
             "count_okay": 0
         },
-        "model": "fpr.fprule",
-        "pk": 800
+        "model": "fpr.fprule"
     },
     {
         "fields": {
@@ -1735,8 +1584,7 @@
             "purpose": "characterization",
             "count_okay": 0
         },
-        "model": "fpr.fprule",
-        "pk": 801
+        "model": "fpr.fprule"
     },
     {
         "fields": {
@@ -1751,8 +1599,7 @@
             "purpose": "characterization",
             "count_okay": 0
         },
-        "model": "fpr.fprule",
-        "pk": 802
+        "model": "fpr.fprule"
     },
     {
         "fields": {
@@ -1767,8 +1614,7 @@
             "purpose": "characterization",
             "count_okay": 0
         },
-        "model": "fpr.fprule",
-        "pk": 803
+        "model": "fpr.fprule"
     },
     {
         "fields": {
@@ -1783,8 +1629,7 @@
             "purpose": "characterization",
             "count_okay": 0
         },
-        "model": "fpr.fprule",
-        "pk": 804
+        "model": "fpr.fprule"
     },
     {
         "fields": {
@@ -1799,8 +1644,7 @@
             "purpose": "characterization",
             "count_okay": 0
         },
-        "model": "fpr.fprule",
-        "pk": 805
+        "model": "fpr.fprule"
     },
     {
         "fields": {
@@ -1815,8 +1659,7 @@
             "purpose": "characterization",
             "count_okay": 0
         },
-        "model": "fpr.fprule",
-        "pk": 806
+        "model": "fpr.fprule"
     },
     {
         "fields": {
@@ -1831,8 +1674,7 @@
             "purpose": "characterization",
             "count_okay": 0
         },
-        "model": "fpr.fprule",
-        "pk": 807
+        "model": "fpr.fprule"
     },
     {
         "fields": {
@@ -1847,8 +1689,7 @@
             "purpose": "characterization",
             "count_okay": 0
         },
-        "model": "fpr.fprule",
-        "pk": 808
+        "model": "fpr.fprule"
     },
     {
         "fields": {
@@ -1863,8 +1704,7 @@
             "purpose": "characterization",
             "count_okay": 0
         },
-        "model": "fpr.fprule",
-        "pk": 809
+        "model": "fpr.fprule"
     },
     {
         "fields": {
@@ -1879,8 +1719,7 @@
             "purpose": "characterization",
             "count_okay": 0
         },
-        "model": "fpr.fprule",
-        "pk": 810
+        "model": "fpr.fprule"
     },
     {
         "fields": {
@@ -1895,8 +1734,7 @@
             "purpose": "characterization",
             "count_okay": 0
         },
-        "model": "fpr.fprule",
-        "pk": 811
+        "model": "fpr.fprule"
     },
     {
         "fields": {
@@ -1911,8 +1749,7 @@
             "purpose": "characterization",
             "count_okay": 0
         },
-        "model": "fpr.fprule",
-        "pk": 812
+        "model": "fpr.fprule"
     },
     {
         "fields": {
@@ -1927,8 +1764,7 @@
             "purpose": "characterization",
             "count_okay": 0
         },
-        "model": "fpr.fprule",
-        "pk": 813
+        "model": "fpr.fprule"
     },
     {
         "fields": {
@@ -1943,8 +1779,7 @@
             "purpose": "characterization",
             "count_okay": 0
         },
-        "model": "fpr.fprule",
-        "pk": 814
+        "model": "fpr.fprule"
     },
     {
         "fields": {
@@ -1959,8 +1794,7 @@
             "purpose": "characterization",
             "count_okay": 0
         },
-        "model": "fpr.fprule",
-        "pk": 815
+        "model": "fpr.fprule"
     },
     {
         "fields": {
@@ -1975,8 +1809,7 @@
             "purpose": "characterization",
             "count_okay": 0
         },
-        "model": "fpr.fprule",
-        "pk": 816
+        "model": "fpr.fprule"
     },
     {
         "fields": {
@@ -1991,8 +1824,7 @@
             "purpose": "characterization",
             "count_okay": 0
         },
-        "model": "fpr.fprule",
-        "pk": 817
+        "model": "fpr.fprule"
     },
     {
         "fields": {
@@ -2007,8 +1839,7 @@
             "purpose": "characterization",
             "count_okay": 0
         },
-        "model": "fpr.fprule",
-        "pk": 818
+        "model": "fpr.fprule"
     },
     {
         "fields": {
@@ -2023,8 +1854,7 @@
             "purpose": "characterization",
             "count_okay": 0
         },
-        "model": "fpr.fprule",
-        "pk": 819
+        "model": "fpr.fprule"
     },
     {
         "fields": {
@@ -2039,8 +1869,7 @@
             "purpose": "characterization",
             "count_okay": 0
         },
-        "model": "fpr.fprule",
-        "pk": 820
+        "model": "fpr.fprule"
     },
     {
         "fields": {
@@ -2055,8 +1884,7 @@
             "purpose": "characterization",
             "count_okay": 0
         },
-        "model": "fpr.fprule",
-        "pk": 821
+        "model": "fpr.fprule"
     },
     {
         "fields": {
@@ -2071,8 +1899,7 @@
             "purpose": "characterization",
             "count_okay": 0
         },
-        "model": "fpr.fprule",
-        "pk": 822
+        "model": "fpr.fprule"
     },
     {
         "fields": {
@@ -2087,8 +1914,7 @@
             "purpose": "characterization",
             "count_okay": 0
         },
-        "model": "fpr.fprule",
-        "pk": 823
+        "model": "fpr.fprule"
     },
     {
         "fields": {
@@ -2103,8 +1929,7 @@
             "purpose": "characterization",
             "count_okay": 0
         },
-        "model": "fpr.fprule",
-        "pk": 824
+        "model": "fpr.fprule"
     },
     {
         "fields": {
@@ -2119,8 +1944,7 @@
             "purpose": "characterization",
             "count_okay": 0
         },
-        "model": "fpr.fprule",
-        "pk": 825
+        "model": "fpr.fprule"
     },
     {
         "fields": {
@@ -2135,8 +1959,7 @@
             "purpose": "characterization",
             "count_okay": 0
         },
-        "model": "fpr.fprule",
-        "pk": 826
+        "model": "fpr.fprule"
     },
     {
         "fields": {
@@ -2151,8 +1974,7 @@
             "purpose": "characterization",
             "count_okay": 0
         },
-        "model": "fpr.fprule",
-        "pk": 827
+        "model": "fpr.fprule"
     },
     {
         "fields": {
@@ -2167,8 +1989,7 @@
             "purpose": "thumbnail",
             "count_okay": 0
         },
-        "model": "fpr.fprule",
-        "pk": 828
+        "model": "fpr.fprule"
     },
     {
         "fields": {
@@ -2180,8 +2001,7 @@
             "command_output": ".jam",
             "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
         },
-        "model": "fpr.idrule",
-        "pk": 775
+        "model": "fpr.idrule"
     },
     {
         "fields": {
@@ -2193,8 +2013,7 @@
             "command_output": ".vox",
             "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
         },
-        "model": "fpr.idrule",
-        "pk": 776
+        "model": "fpr.idrule"
     },
     {
         "fields": {
@@ -2206,8 +2025,7 @@
             "command_output": ".dwfx",
             "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
         },
-        "model": "fpr.idrule",
-        "pk": 777
+        "model": "fpr.idrule"
     },
     {
         "fields": {
@@ -2219,8 +2037,7 @@
             "command_output": ".max",
             "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
         },
-        "model": "fpr.idrule",
-        "pk": 778
+        "model": "fpr.idrule"
     },
     {
         "fields": {
@@ -2232,8 +2049,7 @@
             "command_output": ".aae",
             "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
         },
-        "model": "fpr.idrule",
-        "pk": 780
+        "model": "fpr.idrule"
     },
     {
         "fields": {
@@ -2245,8 +2061,7 @@
             "command_output": ".ezdraw",
             "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
         },
-        "model": "fpr.idrule",
-        "pk": 781
+        "model": "fpr.idrule"
     },
     {
         "fields": {
@@ -2258,8 +2073,7 @@
             "command_output": ".iMovieProj",
             "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
         },
-        "model": "fpr.idrule",
-        "pk": 782
+        "model": "fpr.idrule"
     },
     {
         "fields": {
@@ -2271,8 +2085,7 @@
             "command_output": ".nib",
             "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
         },
-        "model": "fpr.idrule",
-        "pk": 783
+        "model": "fpr.idrule"
     },
     {
         "fields": {
@@ -2284,8 +2097,7 @@
             "command_output": ".vtf",
             "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
         },
-        "model": "fpr.idrule",
-        "pk": 784
+        "model": "fpr.idrule"
     },
     {
         "fields": {
@@ -2297,8 +2109,7 @@
             "command_output": ".onepkg",
             "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
         },
-        "model": "fpr.idrule",
-        "pk": 785
+        "model": "fpr.idrule"
     },
     {
         "fields": {
@@ -2310,8 +2121,7 @@
             "command_output": ".3dd",
             "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
         },
-        "model": "fpr.idrule",
-        "pk": 786
+        "model": "fpr.idrule"
     },
     {
         "fields": {
@@ -2323,8 +2133,7 @@
             "command_output": ".sha256",
             "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
         },
-        "model": "fpr.idrule",
-        "pk": 787
+        "model": "fpr.idrule"
     },
     {
         "fields": {
@@ -2336,8 +2145,7 @@
             "command_output": ".sha1",
             "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
         },
-        "model": "fpr.idrule",
-        "pk": 788
+        "model": "fpr.idrule"
     },
     {
         "fields": {
@@ -2349,8 +2157,7 @@
             "command_output": ".md5",
             "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
         },
-        "model": "fpr.idrule",
-        "pk": 789
+        "model": "fpr.idrule"
     },
     {
         "fields": {
@@ -2362,8 +2169,7 @@
             "command_output": ".jif",
             "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
         },
-        "model": "fpr.idrule",
-        "pk": 790
+        "model": "fpr.idrule"
     },
     {
         "fields": {
@@ -2375,8 +2181,7 @@
             "command_output": ".psb",
             "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
         },
-        "model": "fpr.idrule",
-        "pk": 791
+        "model": "fpr.idrule"
     },
     {
         "fields": {
@@ -2388,8 +2193,7 @@
             "command_output": ".por",
             "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
         },
-        "model": "fpr.idrule",
-        "pk": 792
+        "model": "fpr.idrule"
     },
     {
         "fields": {
@@ -2401,8 +2205,7 @@
             "command_output": ".ora",
             "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
         },
-        "model": "fpr.idrule",
-        "pk": 793
+        "model": "fpr.idrule"
     },
     {
         "fields": {
@@ -2414,8 +2217,7 @@
             "command_output": ".kra",
             "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
         },
-        "model": "fpr.idrule",
-        "pk": 794
+        "model": "fpr.idrule"
     },
     {
         "fields": {
@@ -2427,8 +2229,7 @@
             "command_output": ".tzx",
             "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
         },
-        "model": "fpr.idrule",
-        "pk": 795
+        "model": "fpr.idrule"
     },
     {
         "fields": {
@@ -2440,8 +2241,7 @@
             "command_output": ".exr",
             "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
         },
-        "model": "fpr.idrule",
-        "pk": 796
+        "model": "fpr.idrule"
     },
     {
         "fields": {
@@ -2453,8 +2253,7 @@
             "command_output": ".nrrd",
             "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
         },
-        "model": "fpr.idrule",
-        "pk": 799
+        "model": "fpr.idrule"
     },
     {
         "fields": {
@@ -2466,8 +2265,7 @@
             "command_output": ".dss",
             "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
         },
-        "model": "fpr.idrule",
-        "pk": 800
+        "model": "fpr.idrule"
     },
     {
         "fields": {
@@ -2479,8 +2277,7 @@
             "command_output": ".ds2",
             "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
         },
-        "model": "fpr.idrule",
-        "pk": 801
+        "model": "fpr.idrule"
     },
     {
         "fields": {
@@ -2492,8 +2289,7 @@
             "command_output": ".fbx",
             "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
         },
-        "model": "fpr.idrule",
-        "pk": 802
+        "model": "fpr.idrule"
     },
     {
         "fields": {
@@ -2505,8 +2301,7 @@
             "command_output": ".itf",
             "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
         },
-        "model": "fpr.idrule",
-        "pk": 803
+        "model": "fpr.idrule"
     },
     {
         "fields": {
@@ -2518,8 +2313,7 @@
             "command_output": ".ili",
             "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
         },
-        "model": "fpr.idrule",
-        "pk": 804
+        "model": "fpr.idrule"
     },
     {
         "fields": {
@@ -2531,8 +2325,7 @@
             "command_output": ".sas7bdat",
             "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
         },
-        "model": "fpr.idrule",
-        "pk": 808
+        "model": "fpr.idrule"
     },
     {
         "fields": {
@@ -2544,8 +2337,7 @@
             "command_output": ".sas7bcat",
             "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
         },
-        "model": "fpr.idrule",
-        "pk": 811
+        "model": "fpr.idrule"
     },
     {
         "fields": {
@@ -2557,8 +2349,7 @@
             "command_output": ".dta",
             "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
         },
-        "model": "fpr.idrule",
-        "pk": 816
+        "model": "fpr.idrule"
     },
     {
         "fields": {
@@ -2570,8 +2361,7 @@
             "command_output": ".rmd",
             "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
         },
-        "model": "fpr.idrule",
-        "pk": 817
+        "model": "fpr.idrule"
     },
     {
         "fields": {
@@ -2583,7 +2373,6 @@
             "command_output": ".dds",
             "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
         },
-        "model": "fpr.idrule",
-        "pk": 818
+        "model": "fpr.idrule"
     }
 ]


### PR DESCRIPTION
I screwed 1.6.1 because I forgot to delete the primary keys from the pronom_90 fixture and I added a couple of records as a result of following the pronom update process in two different computers, i.e. `lastmodification` timestamps were different and `get_fpr_changes` considered them different so they were included in the fixture causing upgrades to break - good that we found this on a release candidate.