### PR TITLE
Add file UUID to OCR text file name

### DIFF
--- a/fpr/__init__.py
+++ b/fpr/__init__.py
@@ -8,4 +8,4 @@
 .. moduleauthor:: Justin Simpson <jsimpson@artefactual.com>
 """
 
-__version__ = '1.7.2'
+__version__ = '1.7.3'

--- a/fpr/migrations/0017_ocr_unique_names.py
+++ b/fpr/migrations/0017_ocr_unique_names.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+def data_migration(apps, schema_editor):
+    """Migration that causes each OCR text file to include the UUID of its
+    source file in its filename. This prevents OCR text files from overwriting
+    one another when there are two identically named source files in a
+    transfer. See
+    https://github.com/artefactual/archivematica-fpr-admin/issues/66
+    """
+    IDCommand = apps.get_model('fpr', 'IDCommand')
+    ocr_command = IDCommand.objects.get(
+        uuid='5d501dbf-76bb-4569-a9db-9e367800995e')
+    ocr_command.command = (
+        'ocrfiles="%SIPObjectsDirectory%metadata/OCRfiles"\n'
+        'test -d "$ocrfiles" || mkdir -p "$ocrfiles"\n\n'
+        'tesseract %fileFullName% "$ocrfiles/%fileName%-%fileUUID%"')
+    ocr_command.output_location = (
+        '%SIPObjectsDirectory%metadata/OCRfiles/%fileName%-%fileUUID%.txt')
+    ocr_command.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('fpr', '0016_update_idtools'),
+    ]
+
+    operations = [
+        migrations.RunPython(data_migration),
+    ]


### PR DESCRIPTION
Adds a migration that causes each OCR text file to include the UUID of its source file in its filename. This prevents OCR text files from overwriting one another when there are two identically named source files in a transfer. Fixes #66. (Cf. https://projects.artefactual.com/issues/11651.)

After this migration, if OCR transcription is turned on and a transfer like the following is run through Archivematica:

```
ocr-expect-breaks/
├── dir1
│   └── abroadcranethoma00craniala_0014.jpg
└── dir2
    └── abroadcranethoma00craniala_0014.jpg
```

Then the relevant part of the resulting AIP should look like:

```
│   ├── objects
│   │   ├── dir1
│   │   │   ├── abroadcranethoma00craniala_0014-88d96c33-cced-499f-bd64-95c0b5fdbd95.tif
│   │   │   └── abroadcranethoma00craniala_0014.jpg
│   │   ├── dir2
│   │   │   ├── abroadcranethoma00craniala_0014-8eccc145-8760-41cf-84e9-79a8b2f4e5f2.tif
│   │   │   └── abroadcranethoma00craniala_0014.jpg
│   │   ├── metadata
│   │   │   ├── OCRfiles
│   │   │   │   ├── abroadcranethoma00craniala_0014-216f6abc-c6dd-4bd4-9720-a2a0b5b0a046.txt
│   │   │   │   └── abroadcranethoma00craniala_0014-4c3fa46b-a468-4e6a-bcda-228488de4a67.txt
│   │   │   └── transfers
│   │   │       └── mon9-9bae9d56-dd93-4a5f-b9c1-1666648fb785
│   │   │           └── directory_tree.txt
```