### PR TITLE
Fix slug overflow in MySQL with strict mode enabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,23 @@
 ---
-language: python
+
 sudo: false
-script:
 
+language: python
 
-  # Test if there are migrations that need to be created
-  - |
-      set -o errexit
-      set -o pipefail
-      testproject/manage.py makemigrations
-      ! git status --porcelain fpr/migrations/ 2>/dev/null | grep "^??"
+jobs:
+  include:
 
-  # Test that we can migrate an empty database
-  - testproject/manage.py migrate
+    - stage: Migration test with SQLite
+      env: "DATABASE_URL=sqlite:////home/travis/build/artefactual/archivematica-fpr-admin/testproject/db.sqlite3"
+      install: pip install -r dev_requirements.txt
+      script: ./scripts/test-migrations.sh
+
+    - stage: Migration test with MySQL
+      env: "DATABASE_URL=mysql://root@127.0.0.1/fpr"
+      services: mysql
+      before_install: "mysql -e 'CREATE DATABASE fpr;'"
+      install: pip install -r dev_requirements.txt
+      script: ./scripts/test-migrations.sh
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,18 @@ jobs:
     - stage: Migration test with SQLite
       env: "DATABASE_URL=sqlite:////home/travis/build/artefactual/archivematica-fpr-admin/testproject/db.sqlite3"
       install: pip install -r dev_requirements.txt
-      script: ./scripts/test-migrations.sh
+      script:
+        - scripts/test-migrations.sh
+        - testproject/manage.py test
 
     - stage: Migration test with MySQL
       env: "DATABASE_URL=mysql://root@127.0.0.1/fpr"
       services: mysql
       before_install: "mysql -e 'CREATE DATABASE fpr;'"
       install: pip install -r dev_requirements.txt
-      script: ./scripts/test-migrations.sh
+      script:
+        - scripts/test-migrations.sh
+        - testproject/manage.py test
 
 notifications:
   email: false

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -7,8 +7,8 @@ Download the sources:
 
 Create the virtual environment and install the requirements:
 
-    $ virtualenv env
-    $ source env/bin/activate
+    $ virtualenv .env
+    $ source .env/bin/activate
     $ pip install -r requirements.txt
 
 Bootstrap database:

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -2,3 +2,8 @@
 
 frozendict==1.2
 lxml==3.8.0
+
+# Specific to testproject/
+dj-database-url==0.4.2
+python-decouple==3.1
+mysqlclient==1.3.12

--- a/fpr/__init__.py
+++ b/fpr/__init__.py
@@ -8,4 +8,4 @@
 .. moduleauthor:: Justin Simpson <jsimpson@artefactual.com>
 """
 
-__version__ = '1.7.3'
+__version__ = '1.7.4'

--- a/fpr/migrations/0018_slug_unique.py
+++ b/fpr/migrations/0018_slug_unique.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import autoslug.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('fpr', '0017_ocr_unique_names'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='format',
+            name='slug',
+            field=autoslug.fields.AutoSlugField(editable=False, populate_from=b'description', unique=True, verbose_name='slug'),
+        ),
+        migrations.AlterField(
+            model_name='formatgroup',
+            name='slug',
+            field=autoslug.fields.AutoSlugField(editable=False, populate_from=b'description', unique=True, verbose_name='slug'),
+        ),
+        migrations.AlterField(
+            model_name='fptool',
+            name='slug',
+            field=autoslug.fields.AutoSlugField(editable=False, populate_from=b'_slug', unique=True, verbose_name='slug'),
+        ),
+        migrations.AlterField(
+            model_name='idtool',
+            name='slug',
+            field=autoslug.fields.AutoSlugField(editable=False, populate_from=b'_slug', always_update=True, unique=True, verbose_name='slug'),
+        ),
+    ]

--- a/fpr/migrations/pronom_92.json
+++ b/fpr/migrations/pronom_92.json
@@ -397,7 +397,7 @@
     },
     {
         "fields": {
-            "slug": "the-neuroimaging-informatics-technology-initiative-2",
+            "slug": "the-neuroimaging-informatics-technology-init-2",
             "group": "9c183a8f-89b7-47cc-a6ba-4ed038cf63d5",
             "uuid": "42b7510a-e4af-4a76-8702-d3eb9910e8dd",
             "description": "The Neuroimaging Informatics Technology Initiative File Format"
@@ -1316,7 +1316,7 @@
             "access_format": false,
             "preservation_format": false,
             "version": "2",
-            "slug": "the-neuroimaging-informatics-technology-initiative-2",
+            "slug": "the-neuroimaging-informatics-technology-init-2",
             "pronom_id": "fmt/1094",
             "description": "The Neuroimaging Informatics Technology Initiative File Format V2 variant1"
         },

--- a/fpr/models.py
+++ b/fpr/models.py
@@ -251,7 +251,9 @@ class IDTool(models.Model):
 
     def _slug(self):
         """ Returns string to be slugified. """
-        return "{} {}".format(self.description, self.version)
+        src = '{} {}'.format(self.description, self.version)
+        encoded = src.encode('utf-8')[:self._meta.get_field('slug').max_length]
+        return encoded.decode('utf-8', 'ignore')
 
 
 # ########### NORMALIZATION ############
@@ -389,7 +391,9 @@ class FPTool(models.Model):
 
     def _slug(self):
         """ Returns string to be slugified. """
-        return "{} {}".format(self.description, self.version)
+        src = '{} {}'.format(self.description, self.version)
+        encoded = src.encode('utf-8')[:self._meta.get_field('slug').max_length]
+        return encoded.decode('utf-8', 'ignore')
 
 
 # ########################### API V1 & V2 MODELS #############################

--- a/fpr/models.py
+++ b/fpr/models.py
@@ -70,7 +70,7 @@ class Format(models.Model):
     uuid = UUIDField(editable=False, unique=True, version=4, help_text=_("Unique identifier"))
     description = models.CharField(_('description'), max_length=128, help_text=_("Common name of format"))
     group = models.ForeignKey('FormatGroup', to_field='uuid', null=True, verbose_name=_('the related group'))
-    slug = AutoSlugField(_('slug'), populate_from='description')
+    slug = AutoSlugField(_('slug'), populate_from='description', unique=True)
 
     class Meta:
         verbose_name = _("Format")
@@ -84,7 +84,7 @@ class FormatGroup(models.Model):
     """ Group/classification for formats.  Eg. image, video, audio. """
     uuid = UUIDField(editable=False, unique=True, version=4, help_text=_("Unique identifier"))
     description = models.CharField(_('description'), max_length=128)
-    slug = AutoSlugField(_('slug'), populate_from='description')
+    slug = AutoSlugField(_('slug'), populate_from='description', unique=True)
 
     class Meta:
         verbose_name = _("Format group")
@@ -238,7 +238,7 @@ class IDTool(models.Model):
     description = models.CharField(_('description'), max_length=256, help_text=_("Name of tool"))
     version = models.CharField(_('version'), max_length=64)
     enabled = models.BooleanField(_('enabled'), default=True)
-    slug = AutoSlugField(_('slug'), populate_from='_slug', always_update=True)
+    slug = AutoSlugField(_('slug'), populate_from='_slug', always_update=True, unique=True)
 
     class Meta:
         verbose_name = _("Format identification tool")
@@ -380,7 +380,7 @@ class FPTool(models.Model):
     description = models.CharField(_('description'), max_length=256, help_text=_("Name of tool"))
     version = models.CharField(_('version'), max_length=64)
     enabled = models.BooleanField(_('enabled'), default=True)
-    slug = AutoSlugField(_('slug'), populate_from='_slug')
+    slug = AutoSlugField(_('slug'), populate_from='_slug', unique=True)
     # Many to many field is on FPCommand
 
     class Meta:

--- a/scripts/test-migrations.sh
+++ b/scripts/test-migrations.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+readonly __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly __root="$(cd "$(dirname "${__dir}")" && pwd)"
+
+# Test if there are migrations that need to be created
+${__root}/testproject/manage.py makemigrations
+! git status --porcelain ${__root}/fpr/migrations/ 2>/dev/null | grep "^??"
+
+# Test that we can migrate an empty database
+${__root}/testproject/manage.py migrate

--- a/testproject/settings.py
+++ b/testproject/settings.py
@@ -2,6 +2,8 @@
 
 import os
 
+from decouple import config
+import dj_database_url
 from django.utils.translation import ugettext_lazy as _
 
 
@@ -60,11 +62,22 @@ TEMPLATES = [
 SECRET_KEY = 'empty'
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(PROJECT_PATH, 'db.sqlite3')
-    }
+    'default': config(
+        'DATABASE_URL',
+        cast=dj_database_url.parse,
+        default='sqlite:///{}'.format(os.path.join(PROJECT_PATH, 'db.sqlite3')),
+    ),
 }
+
+# Ensure that the strict mode is enabled when using MySQL. This forces MySQL to
+# return an error instead of a warning which helps us to find incompatibilities
+# with the strict mode even when using MySQL 5.5 - the one provided by
+# Travis CI or frequently deployed in Ubuntu Trusty.
+if DATABASES['default']['ENGINE'] == 'django.db.backends.mysql':
+    DATABASES['default']['OPTIONS'] = {
+        'init_command': "SET sql_mode='STRICT_TRANS_TABLES';"
+                        "SET innodb_strict_mode=1;",
+    }
 
 DATABASE_SUPPORTS_TRANSACTIONS = True
 

--- a/testproject/tests/test_autoslug_fields.py
+++ b/testproject/tests/test_autoslug_fields.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+
+from django.test import TestCase
+
+from fpr.models import (
+    Format,
+    FormatGroup,
+    FormatVersion,
+    IDTool,
+    FPTool,
+)
+
+STR_GT_50CH = 'Lorem ipsum dolor sit amet, consectetur adipiscing elitam.'
+STR_GT_50CH_SLUG_1 = 'lorem-ipsum-dolor-sit-amet-consectetur-adipiscing-'
+STR_GT_50CH_SLUG_2 = 'lorem-ipsum-dolor-sit-amet-consectetur-adipiscin-2'
+
+STR_EQ_50CH = 'Lorem ipsum dolor sit amet, consectetur fand elitam.'
+STR_EQ_50CH_SLUG_1 = 'lorem-ipsum-dolor-sit-amet-consectetur-fand-elitam'
+STR_EQ_50CH_SLUG_2 = 'lorem-ipsum-dolor-sit-amet-consectetur-fand-elit-2'
+
+STR_LT_50CH = 'Lorem ipsum dolor sit amet, fand elit.'
+STR_LT_50CH_SLUG_1 = 'lorem-ipsum-dolor-sit-amet-fand-elit'
+STR_LT_50CH_SLUG_2 = 'lorem-ipsum-dolor-sit-amet-fand-elit-2'
+
+
+class AutoSlugFieldsTest(TestCase):
+
+    def run_basic_length_tests_against_model(self, model, field):
+        obj = model.objects.create(**{field: STR_GT_50CH})
+        self.assertEqual(obj.slug, STR_GT_50CH_SLUG_1)
+        self.assertLessEqual(
+            len(obj.slug),
+            Format._meta.get_field('slug').max_length)
+
+        obj = model.objects.create(**{field: STR_GT_50CH})
+        self.assertEqual(obj.slug, STR_GT_50CH_SLUG_2)
+
+        obj = Format.objects.create(**{field: STR_EQ_50CH})
+        self.assertEqual(obj.slug, STR_EQ_50CH_SLUG_1)
+
+        obj = Format.objects.create(**{field: STR_EQ_50CH})
+        self.assertEqual(obj.slug, STR_EQ_50CH_SLUG_2)
+
+        obj = Format.objects.create(**{field: STR_LT_50CH})
+        self.assertEqual(obj.slug, STR_LT_50CH_SLUG_1)
+
+        obj = Format.objects.create(**{field: STR_LT_50CH})
+        self.assertEqual(obj.slug, STR_LT_50CH_SLUG_2)
+
+    def test_format_group_slug_field(self):
+        self.run_basic_length_tests_against_model(FormatGroup, 'description')
+
+    def test_format_slug_field(self):
+        self.run_basic_length_tests_against_model(Format, 'description')
+
+    def test_format_version_slug_field(self):
+        fmt1 = Format.objects.create(description='My format A')
+        fmt2 = Format.objects.create(description='My format B')
+        obj1 = FormatVersion.objects.create(format=fmt1, description='FormatV')
+        obj2 = FormatVersion.objects.create(format=fmt2, description='FormatV')
+        obj3 = FormatVersion.objects.create(format=fmt2, description='FormatV')
+
+        self.assertEqual(fmt1.slug, 'my-format-a')
+        self.assertEqual(fmt2.slug, 'my-format-b')
+        self.assertEqual(obj1.slug, 'formatv')
+        self.assertEqual(obj2.slug, 'formatv')
+        self.assertEqual(obj3.slug, 'formatv-2')
+
+        obj3.description = 'New description'
+        obj3.save()
+        self.assertEqual(obj3.slug, 'new-description')
+
+    def test_idtool_slug_field(self):
+        id1 = IDTool.objects.create(description='The Tool', version='3.0.0')
+        id2 = IDTool.objects.create(description='The Tool', version='3.0.0')
+
+        self.assertEqual(id1.slug, 'the-tool-300')
+        self.assertEqual(id2.slug, 'the-tool-300-2')
+
+        id2.description = 'New description'
+        id2.save()
+        self.assertEqual(id2.slug, 'new-description-300')
+
+    def test_fptool_slug_field(self):
+        id1 = FPTool.objects.create(description='The Tool', version='3.0.0')
+        id2 = FPTool.objects.create(description='The Tool', version='3.0.0')
+
+        self.assertEqual(id1.slug, 'the-tool-300')
+        self.assertEqual(id2.slug, 'the-tool-300-2')


### PR DESCRIPTION
The issue was originally reported by @scollazo here: https://github.com/artefactual/archivematica/issues/792. It's an error seen in recent versions of MySQL where the strict mode comes enabled by default.

- Truncate slugs in `pronom_92.json` (fixes https://github.com/artefactual/archivematica/issues/792)
- Update custom `_slug` generators to truncate candidates properly (fixes https://github.com/artefactual/archivematica/issues/792)
- Add `unique=True` to all the slug fields (fixes #64)
- Testing: Update Travis CI to test against both MySQL (strict mode) and SQLite
- Testing: Add e2e tests to `testproject/`

And bumped version to 1.7.4.