### PR TITLE
Display PRONOM ID for FormatVersions

### DIFF
--- a/fpr/models.py
+++ b/fpr/models.py
@@ -128,7 +128,7 @@ class FormatVersion(VersionedModel, models.Model):
                 })
 
     def __unicode__(self):
-        return _("%(format)s: %(description)s") % {'format': self.format, 'description': self.description}
+        return _("%(format)s: %(description)s (%(pronom_id)s)") % {'format': self.format, 'description': self.description, 'pronom_id': self.pronom_id}
 
 
 # ########### ID TOOLS ############


### PR DESCRIPTION
Hi Artefactual! This is a small suggested change that resulted from a lot of work here creating new Format Policy Rules. The description currently given for format versions in the FPRuleForm is often identical between several distinct versions of a format. By adding the PRONOM ID to the __unicode__ return, I'm hoping to make it easier to distinguish between similar format versions and select the appropriate option from the list when creating or editing FPR rules.