### PR TITLE
MediaConch: updated to 17.12 and reduce verbosity

### DIFF
--- a/fpr/__init__.py
+++ b/fpr/__init__.py
@@ -8,4 +8,4 @@
 .. moduleauthor:: Justin Simpson <jsimpson@artefactual.com>
 """
 
-__version__ = '1.7.4'
+__version__ = '1.7.5'

--- a/fpr/migrations-data/mc_validate_cmd.py
+++ b/fpr/migrations-data/mc_validate_cmd.py
@@ -21,11 +21,10 @@ Parse = namedtuple('Parse', 'etree_el stdout')
 
 
 def parse_mediaconch_data(target):
-    """Run `mediaconch -mc -fx <target>` against `target` and return an
+    """Run `mediaconch -mc -fx -iv 4 <target>` against `target` and return an
     lxml etree parse of the output.
     """
-
-    args = ['mediaconch', '-mc', '-fx', target]
+    args = ['mediaconch', '-mc', '-fx', '-iv', '4', target]
     try:
         output = subprocess.check_output(args)
     except subprocess.CalledProcessError:
@@ -79,9 +78,7 @@ def get_impl_checks(doc):
     function returns a dict mapping implementation check names to dicts that
     map individual check names to lists of test outcomes, i.e., 'pass' or
     'fail'.
-
     """
-
     impl_checks = {}
     path = '.%smedia/%simplementationChecks' % (NS, NS)
     for impl_check_el in doc.iterfind(path):
@@ -94,12 +91,10 @@ def get_impl_checks(doc):
 
 def get_event_outcome_information_detail(impl_checks):
     """Return a 2-tuple of info and detail.
-
     - info: 'pass' or 'fail'
     - detail: human-readable string indicating which implementation checks
       passed or failed. If implementation check as a whole passed, just return
       the passed check names; if it failed, just return the failed ones.
-
     """
     info = 'pass'
     failed_impl_checks = []
@@ -138,7 +133,6 @@ def main(target):
     `target` is a valid Matroska (.mkv) file. Parse the XML output by
     MediaConch and print a JSON representation of that output.
     """
-
     try:
         parse = parse_mediaconch_data(target)
         impl_checks = get_impl_checks(parse.etree_el)

--- a/fpr/migrations/0011_mediaconch_validation.py
+++ b/fpr/migrations/0011_mediaconch_validation.py
@@ -33,9 +33,9 @@ def data_migration(apps, schema_editor):
     mediaconch_tool = FPTool.objects.create(
         uuid=mediaconch_tool_uuid,
         description='MediaConch',
-        version='16.12',
+        version='17.12',
         enabled=True,
-        slug='mediaconch-1612'
+        slug='mediaconch-1712'
     )
 
     # MediaConch Validation FPR Command


### PR DESCRIPTION
Adds two new migrations so that both matroska validation and policy checking use MediaConch v. 17.12 and so that matroska validation requests less verbose output from MediaConch. Also bumps version to 1.7.5.

Contributes to fixing https://github.com/artefactual/archivematica/issues/966.