### PR TITLE
Pass when multiple FormatVersions are returned

### DIFF
--- a/fpr/management/commands/import_pronom_ids.py
+++ b/fpr/management/commands/import_pronom_ids.py
@@ -119,7 +119,7 @@ def main(pronom_xml, output_format=SQL_OUTPUT, output_file=sys.stdout):
             FormatVersion.objects.get(pronom_id=puid)
             print('Ignoring {}'.format(puid))
             continue
-        except FormatVersion.DoesNotExist:
+        except (FormatVersion.DoesNotExist, FormatVersion.MultipleObjectsReturned):
             print('DOES NOT EXIST OK!')
             pass
 


### PR DESCRIPTION
Allows script to run and bypass issues discovered in the FPR database with multiple FormatVersions returned and associated with a Formats (there should be only one).


This is connected to https://github.com/archivematica/Issues/issues/110.