### PR TITLE
Show PRONOM IDs per format in browse list

### DIFF
--- a/fpr/templates/fpr/format/list.html
+++ b/fpr/templates/fpr/format/list.html
@@ -41,9 +41,9 @@
             <td><a href="{% url 'format_detail' format.slug %}">{{ format.description }}</a></td>
             <td>
               {% if request.user.is_superuser %}
-                <a href="{% url 'formatgroup_edit' format.group.slug %}">{{ format.group }}</a>
+                <a href="{% url 'formatgroup_edit' format.group_slug %}">{{ format.group_name }}</a>
               {% else %}
-                {{ format.group }}
+                {{ format.group_name }}
               {% endif %}
             </td>
             <td>

--- a/fpr/views.py
+++ b/fpr/views.py
@@ -63,9 +63,10 @@ def toggle_enabled(request, category, uuid):
 # ########### FORMATS ############
 
 def format_list(request):
-    formats = fprmodels.Format.objects.filter()
-    # TODO Formats grouped by FormatGroup for better display in template
-    return render(request, 'fpr/format/list.html', context(locals()))
+    return render(request, 'fpr/format/list.html', {
+        # TODO: use paginator or something like django_datatables_view.
+        'formats': fprmodels.Format.objects.get_full_list(),
+    })
 
 
 def format_detail(request, slug):


### PR DESCRIPTION
Temporary solution to include PRONOM IDs in the format list page with a
single SQL query until we have time to have DataTables hit the backend
via XHR or use a simple paginator.

Replaces https://github.com/artefactual/archivematica-fpr-admin/pull/84.
Connects to https://github.com/archivematica/Issues/issues/132.