### PR TITLE
Upgrade to PRONOM 94 while eliminating duplicates

### DIFF
--- a/fpr/migrations/0022_pronom_94.py
+++ b/fpr/migrations/0022_pronom_94.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import os
+
+from django.core.management import call_command
+from django.db import migrations
+
+def data_migration(apps, schema_editor):
+    fixture_file = os.path.join(os.path.dirname(__file__), 'pronom_94.json')
+    call_command('loaddata', fixture_file, app_label='fpr')
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('fpr', '0021_normalize_jp2_with_ffmpeg_for_preservation'),
+    ]
+
+    operations = [
+        migrations.RunPython(data_migration),
+    ]

--- a/fpr/migrations/pronom_93.json
+++ b/fpr/migrations/pronom_93.json
@@ -146,102 +146,6 @@
     {
         "fields": {
             "replaces": null,
-            "uuid": "49073505-f8cd-47f3-9041-7b77aa874ff8",
-            "format": "9b3f9406-a375-4b66-9081-61a317e68cbf",
-            "lastmodified": "2018-08-28T23:58:46.526Z",
-            "enabled": true,
-            "access_format": false,
-            "preservation_format": false,
-            "version": "1.0",
-            "slug": "wordperfect-graphics-10-2",
-            "pronom_id": "x-fmt/395",
-            "description": "WordPerfect Graphics 1.0"
-        },
-        "model": "fpr.formatversion"
-    },
-    {
-        "fields": {
-            "replaces": null,
-            "uuid": "e8de9743-ac2b-432a-8662-7408b309546f",
-            "format": "9b3f9406-a375-4b66-9081-61a317e68cbf",
-            "lastmodified": "2018-08-28T23:58:47.215Z",
-            "enabled": true,
-            "access_format": false,
-            "preservation_format": false,
-            "version": "2.0",
-            "slug": "wordperfect-graphics-20-2",
-            "pronom_id": "fmt/1042",
-            "description": "WordPerfect Graphics 2.0"
-        },
-        "model": "fpr.formatversion"
-    },
-    {
-        "fields": {
-            "replaces": null,
-            "uuid": "48d1cfab-b938-4242-b1b6-a642dce5ec8f",
-            "format": "1a91d8c5-7bfb-47b1-9e4c-8dd934f33cda",
-            "lastmodified": "2018-08-28T23:58:47.268Z",
-            "enabled": true,
-            "access_format": false,
-            "preservation_format": false,
-            "version": "3",
-            "slug": "hwp-3-2",
-            "pronom_id": "fmt/1083",
-            "description": "HWP 3"
-        },
-        "model": "fpr.formatversion"
-    },
-    {
-        "fields": {
-            "replaces": null,
-            "uuid": "ec196238-2461-4066-bd05-ee9210286e7e",
-            "format": "9b3f9406-a375-4b66-9081-61a317e68cbf",
-            "lastmodified": "2018-08-29T00:02:12.463Z",
-            "enabled": true,
-            "access_format": false,
-            "preservation_format": false,
-            "version": "1.0",
-            "slug": "wordperfect-graphics-10-3",
-            "pronom_id": "x-fmt/395",
-            "description": "WordPerfect Graphics 1.0"
-        },
-        "model": "fpr.formatversion"
-    },
-    {
-        "fields": {
-            "replaces": null,
-            "uuid": "82cad44c-0f23-4fc9-b7b7-d08ce2e48511",
-            "format": "9b3f9406-a375-4b66-9081-61a317e68cbf",
-            "lastmodified": "2018-08-29T00:02:13.200Z",
-            "enabled": true,
-            "access_format": false,
-            "preservation_format": false,
-            "version": "2.0",
-            "slug": "wordperfect-graphics-20-3",
-            "pronom_id": "fmt/1042",
-            "description": "WordPerfect Graphics 2.0"
-        },
-        "model": "fpr.formatversion"
-    },
-    {
-        "fields": {
-            "replaces": null,
-            "uuid": "938fec89-28f5-4448-bbd0-fdcf298ad3e1",
-            "format": "1a91d8c5-7bfb-47b1-9e4c-8dd934f33cda",
-            "lastmodified": "2018-08-29T00:02:13.260Z",
-            "enabled": true,
-            "access_format": false,
-            "preservation_format": false,
-            "version": "3",
-            "slug": "hwp-3-3",
-            "pronom_id": "fmt/1083",
-            "description": "HWP 3"
-        },
-        "model": "fpr.formatversion"
-    },
-    {
-        "fields": {
-            "replaces": null,
             "uuid": "6fdfc554-be9b-48c7-89cc-5f24c4037564",
             "format": "7960e5c5-4ef6-4696-a86f-f6314fb6cee4",
             "lastmodified": "2018-08-29T00:02:13.291Z",
@@ -734,18 +638,6 @@
             "description": "Gatan Digital Micrograph 3"
         },
         "model": "fpr.formatversion"
-    },
-    {
-        "fields": {
-            "replaces": null,
-            "uuid": "861eb463-497a-4ec4-a506-41b88c1191f0",
-            "format": "82cad44c-0f23-4fc9-b7b7-d08ce2e48511",
-            "lastmodified": "2018-08-29T00:02:13.214Z",
-            "enabled": true,
-            "command_output": ".wpg",
-            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
-        },
-        "model": "fpr.idrule"
     },
     {
         "fields": {

--- a/fpr/migrations/pronom_94.json
+++ b/fpr/migrations/pronom_94.json
@@ -1,0 +1,2602 @@
+[
+    {
+        "fields": {
+            "slug": "netscape-bookmark-file-format",
+            "group": "89961b53-4d5c-49e2-9910-8825d96c8640",
+            "uuid": "5b3060f7-97c6-439f-8474-b885f2132ba8",
+            "description": "Netscape Bookmark File Format"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "farbfeld-image-format",
+            "group": "be86edbf-f62c-431f-b549-300d23c7cd0d",
+            "uuid": "978b0fb0-60eb-4c3a-9baa-ac01d519c41f",
+            "description": "Farbfeld Image Format"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "gps-exchange-format-2",
+            "group": "89961b53-4d5c-49e2-9910-8825d96c8640",
+            "uuid": "5c0d5ec2-5a77-4df5-a948-9bbb3685c87d",
+            "description": "GPS Exchange Format"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "minicad",
+            "group": "8d32bf98-b569-4469-8953-10416b53b920",
+            "uuid": "eb7a5a58-8909-4510-84c8-11cdd1d0ddf5",
+            "description": "MiniCAD"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "minicadvectorworks",
+            "group": "8d32bf98-b569-4469-8953-10416b53b920",
+            "uuid": "2df75fa9-f215-4183-95c2-82a91d62342b",
+            "description": "MiniCAD/VectorWorks"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "vectorworks-plugin-or-script",
+            "group": "8d32bf98-b569-4469-8953-10416b53b920",
+            "uuid": "dc61a606-ed49-435f-8828-f83a63e34824",
+            "description": "VectorWorks Plugin or Script"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "zisraw-czi-file-format",
+            "group": "9c183a8f-89b7-47cc-a6ba-4ed038cf63d5",
+            "uuid": "990c9c18-f817-42da-a0ee-83fce0241bff",
+            "description": "ZISRAW (CZI) File Format"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "compuserve-wincim-message-format",
+            "group": "5b14d57c-d6f1-4807-b98d-0a574d6bf8fc",
+            "uuid": "0a3e9e20-1a0f-45cc-ada4-53fed9696079",
+            "description": "CompuServe WinCIM Message Format"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "maxwell-render-material-file",
+            "group": "8d32bf98-b569-4469-8953-10416b53b920",
+            "uuid": "9ec25ef4-0123-40dd-aa50-dde40e159922",
+            "description": "Maxwell Render Material File"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "maxwell-render-image-format",
+            "group": "be86edbf-f62c-431f-b549-300d23c7cd0d",
+            "uuid": "1d8c2214-3490-44a6-85a8-e8e9ec3aab62",
+            "description": "Maxwell Render Image Format"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "sidoun-winava-format",
+            "group": "8d32bf98-b569-4469-8953-10416b53b920",
+            "uuid": "7cfae2d1-3eb4-4c3c-9469-5b9fd68c0b40",
+            "description": "SIDOUN WinAVA Format"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "maxwell-render-scene-file-format",
+            "group": "8d32bf98-b569-4469-8953-10416b53b920",
+            "uuid": "4077db50-39a3-4428-b5f0-d532e28917ce",
+            "description": "Maxwell Render Scene File Format"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "markdown",
+            "group": "89961b53-4d5c-49e2-9910-8825d96c8640",
+            "uuid": "ba07114c-fe3b-4fcf-a6e5-650a896453ea",
+            "description": "Markdown"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "4x-movie-file",
+            "group": "f22e9c29-9d4a-429e-adaf-38f3aecaff99",
+            "uuid": "38ca6c74-52b5-45fc-8589-09fd158d68d9",
+            "description": "4X Movie File"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "lightwright-show-file",
+            "group": "00abbdd0-51b3-4162-b93a-45deb4ed8654",
+            "uuid": "2393e5f4-901d-4745-a0b8-470afa63ef39",
+            "description": "Lightwright Show File"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "folio-infobase-file",
+            "group": "7d161ac1-2879-445d-8e6d-cbc9eff5c225",
+            "uuid": "7f23c084-855a-42e9-a1d2-741753f8b9f1",
+            "description": "Folio Infobase File"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "folio-shadow-file",
+            "group": "7d161ac1-2879-445d-8e6d-cbc9eff5c225",
+            "uuid": "ed81b563-77d4-41a0-8633-aaef3e2fc714",
+            "description": "Folio Shadow File"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "folio-flat-file",
+            "group": "7d161ac1-2879-445d-8e6d-cbc9eff5c225",
+            "uuid": "1076735d-77ac-4f84-b7ee-81d52bac90ed",
+            "description": "Folio Flat File"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "folio-definition-file",
+            "group": "7d161ac1-2879-445d-8e6d-cbc9eff5c225",
+            "uuid": "10bf0cb1-2135-4767-b564-5875d88dfe3d",
+            "description": "Folio Definition File"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "praat-picture-file",
+            "group": "be86edbf-f62c-431f-b549-300d23c7cd0d",
+            "uuid": "c244cf05-0e65-4aca-97c0-2c1c1c04baa5",
+            "description": "Praat Picture File"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "praat-script-file",
+            "group": "57361413-1c3b-405d-a9c0-7d3ea381090e",
+            "uuid": "c58b339b-12ea-4bdd-9d40-2f593c5d01d2",
+            "description": "Praat Script File"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "niton-data-transfer",
+            "group": "9c183a8f-89b7-47cc-a6ba-4ed038cf63d5",
+            "uuid": "9e633418-8e77-40a9-94e0-7ae7f10ea802",
+            "description": "Niton Data Transfer"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "softimage-3d-picture-file-format",
+            "group": "be86edbf-f62c-431f-b549-300d23c7cd0d",
+            "uuid": "b5f8fc88-fbac-4aa2-b0be-c6369392cd06",
+            "description": "Softimage 3D Picture File Format"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "maya-icons-or-swatches-file",
+            "group": "be86edbf-f62c-431f-b549-300d23c7cd0d",
+            "uuid": "43ca4a6c-af1b-4376-a637-919834fcaed0",
+            "description": "Maya Icons or Swatches file"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "maya-iff-image-file",
+            "group": "be86edbf-f62c-431f-b549-300d23c7cd0d",
+            "uuid": "844670f7-fde5-4a33-94df-c67177edef32",
+            "description": "Maya IFF Image File"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "alias-studio-wire-file",
+            "group": "8d32bf98-b569-4469-8953-10416b53b920",
+            "uuid": "afdd61a4-406e-4ef6-8593-9065e8cf239a",
+            "description": "Alias Studio Wire File"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "alias-poweranimator-file",
+            "group": "8d32bf98-b569-4469-8953-10416b53b920",
+            "uuid": "6fb8b85b-7826-4f1a-899a-e8f37145c63c",
+            "description": "Alias PowerAnimator File"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "framemd5",
+            "group": "00abbdd0-51b3-4162-b93a-45deb4ed8654",
+            "uuid": "781f315e-cd6a-4d8e-a8ac-301b897fd954",
+            "description": "FrameMD5"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "nullsoft-streaming-video",
+            "group": "f22e9c29-9d4a-429e-adaf-38f3aecaff99",
+            "uuid": "7269b84a-a5df-4b19-932e-e7e839b9d1d9",
+            "description": "Nullsoft Streaming Video"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "microstation-material-library",
+            "group": "00abbdd0-51b3-4162-b93a-45deb4ed8654",
+            "uuid": "46496986-d7a5-4671-b192-e2e08ab227e7",
+            "description": "MicroStation Material Library"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "synthetic-music-mobile-application-format",
+            "group": "c94ce0e6-c275-4c09-b802-695a18b7bf2a",
+            "uuid": "e477b2c0-2a17-497c-864e-f6375fb76427",
+            "description": "Synthetic Music Mobile Application Format"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "away3d-data-format",
+            "group": "8d32bf98-b569-4469-8953-10416b53b920",
+            "uuid": "a45ef95d-7c1e-40f0-aab4-20a1e268f5eb",
+            "description": "Away3D Data Format"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "bodypaint-3d",
+            "group": "be86edbf-f62c-431f-b549-300d23c7cd0d",
+            "uuid": "1debc5fc-ed31-4bdc-8f39-b7b11d847c7f",
+            "description": "Bodypaint 3D"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "blitz3d-file-format",
+            "group": "8d32bf98-b569-4469-8953-10416b53b920",
+            "uuid": "29853f2a-24d7-4306-93d9-e7eec3cf1a09",
+            "description": "Blitz3D File Format"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "microstation-material-palette",
+            "group": "00abbdd0-51b3-4162-b93a-45deb4ed8654",
+            "uuid": "6e828574-c3a6-4c8b-a1e1-b6ef89919592",
+            "description": "MicroStation Material Palette"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "indesign-markup-language-package",
+            "group": "3616a69f-e9c4-4357-b366-57082cf75a3e",
+            "uuid": "6631c09c-0363-4f10-a65f-49f8bdbae658",
+            "description": "InDesign Markup Language Package"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "apple-icon-image-format",
+            "group": "be86edbf-f62c-431f-b549-300d23c7cd0d",
+            "uuid": "bbf96270-946b-476a-9bea-164584eeea4c",
+            "description": "Apple Icon Image Format"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "dr-halo-image-palette",
+            "group": "be86edbf-f62c-431f-b549-300d23c7cd0d",
+            "uuid": "97bf687e-e984-428d-8367-23cc656b0470",
+            "description": "Dr. Halo Image Palette"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "iwork13-template",
+            "group": "00abbdd0-51b3-4162-b93a-45deb4ed8654",
+            "uuid": "2b6660e8-22b0-4548-b234-683848e5a8c5",
+            "description": "iWork13 Template"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "ogre-mesh-1x",
+            "group": "8d32bf98-b569-4469-8953-10416b53b920",
+            "uuid": "c73d8d8e-a021-4925-850b-b70ae51e53ef",
+            "description": "Ogre Mesh 1.x"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "ogre-mesh-xml",
+            "group": "8d32bf98-b569-4469-8953-10416b53b920",
+            "uuid": "ed385839-0f26-40ba-badb-3595692dc766",
+            "description": "Ogre Mesh XML"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "adobe-swc-package",
+            "group": "00abbdd0-51b3-4162-b93a-45deb4ed8654",
+            "uuid": "f689631e-c032-4de5-a412-31a221e9fdc9",
+            "description": "Adobe SWC Package"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "adobe-indesign-book",
+            "group": "3616a69f-e9c4-4357-b366-57082cf75a3e",
+            "uuid": "f133eeaf-fb8a-4eb6-b710-033dc3c804e7",
+            "description": "Adobe InDesign Book"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "adobe-indesign-library",
+            "group": "00abbdd0-51b3-4162-b93a-45deb4ed8654",
+            "uuid": "5c6e0640-4290-435c-8ef2-ccaba6f28ac0",
+            "description": "Adobe InDesign Library"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "zmodeler-z3d",
+            "group": "8d32bf98-b569-4469-8953-10416b53b920",
+            "uuid": "e312bcbc-6a87-4b04-9b61-bc80880a5602",
+            "description": "ZModeler Z3D"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "myisam-indexes-file",
+            "group": "7d161ac1-2879-445d-8e6d-cbc9eff5c225",
+            "uuid": "a371e779-774d-49cb-be8e-84824ebcb9c3",
+            "description": "MyISAM Indexes File"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "rdata",
+            "group": "9c183a8f-89b7-47cc-a6ba-4ed038cf63d5",
+            "uuid": "8030524e-c0fc-4c84-b68e-1399909c0d7c",
+            "description": "RData"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "powerdraw",
+            "group": "00abbdd0-51b3-4162-b93a-45deb4ed8654",
+            "uuid": "e1a0ebc4-c771-4ddc-ba7a-6195d617be0a",
+            "description": "PowerDraw"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "powercadd",
+            "group": "00abbdd0-51b3-4162-b93a-45deb4ed8654",
+            "uuid": "d75fdc87-7cb9-40c8-88eb-e0bb729efb5e",
+            "description": "PowerCADD"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "guymager-acquisition-info-file",
+            "group": "57361413-1c3b-405d-a9c0-7d3ea381090e",
+            "uuid": "b13b0930-0c1d-48a8-b6b1-0e97c68b0f36",
+            "description": "Guymager Acquisition Info File"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "strata-studiopro-vis-format",
+            "group": "8d32bf98-b569-4469-8953-10416b53b920",
+            "uuid": "7d0104af-3e60-4810-81d6-35814301d230",
+            "description": "Strata StudioPro Vis Format"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "lightwave-3d-object",
+            "group": "8d32bf98-b569-4469-8953-10416b53b920",
+            "uuid": "3e96362a-3231-46fc-99e0-51c4de245a38",
+            "description": "LightWave 3D Object"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "impulse-3d-data-description-object",
+            "group": "8d32bf98-b569-4469-8953-10416b53b920",
+            "uuid": "2705a991-d26b-4baa-b056-16fcc5ec21f2",
+            "description": "Impulse 3D Data Description Object"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "sony-sfk-file",
+            "group": "9c183a8f-89b7-47cc-a6ba-4ed038cf63d5",
+            "uuid": "ef201044-29e4-435e-ae02-bc618ab17c6c",
+            "description": "Sony SFK File"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "virtools-file-format",
+            "group": "00abbdd0-51b3-4162-b93a-45deb4ed8654",
+            "uuid": "22e69086-5e82-4a29-9729-7842a45b633f",
+            "description": "Virtools File Format"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "collada-digital-asset-exchange-dae",
+            "group": "8d32bf98-b569-4469-8953-10416b53b920",
+            "uuid": "e9891d02-e8a8-487d-a9c2-a67cc59006a5",
+            "description": "COLLADA Digital Asset Exchange (DAE)"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "wavefront-obj-file",
+            "group": "8d32bf98-b569-4469-8953-10416b53b920",
+            "uuid": "d30ae8db-1264-4741-9870-8af721304aca",
+            "description": "Wavefront OBJ File"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "wavefront-material-template-library",
+            "group": "00abbdd0-51b3-4162-b93a-45deb4ed8654",
+            "uuid": "d03549ac-9297-4573-afd1-092273ea2414",
+            "description": "Wavefront Material Template Library"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "hp-system-software-manager-cva-file",
+            "group": "57361413-1c3b-405d-a9c0-7d3ea381090e",
+            "uuid": "21d2a24c-6638-4add-96ff-8dbbf47a44a7",
+            "description": "HP System Software Manager CVA File"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "zoner-callisto-metafile",
+            "group": "fdf9e267-a18c-46a4-a162-b81bcba6322f",
+            "uuid": "c768ff66-b7fc-4c0b-a20c-37329576b804",
+            "description": "Zoner Callisto Metafile"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "cakewalk-wrk-project",
+            "group": "c94ce0e6-c275-4c09-b802-695a18b7bf2a",
+            "uuid": "917e41f3-de98-4908-905c-2a7558af0d22",
+            "description": "Cakewalk WRK Project"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "erdas-hierarchical-file-architecture-format",
+            "group": "e8d06de7-f66c-4792-b7d4-3f17a22ab313",
+            "uuid": "a220abd2-34b9-401a-8289-c6e740d91940",
+            "description": "ERDAS Hierarchical File Architecture Format"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "lotus-freelance-show",
+            "group": "3616a69f-e9c4-4357-b366-57082cf75a3e",
+            "uuid": "82365ae6-180a-4ae1-bb06-127eafa38237",
+            "description": "Lotus Freelance Show"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "slug": "leonardo-image-format",
+            "group": "be86edbf-f62c-431f-b549-300d23c7cd0d",
+            "uuid": "f715eeb3-2de4-4032-a7eb-0c64dcbb9796",
+            "description": "Leonardo Image Format"
+        },
+        "model": "fpr.format"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "28627ddf-e2e0-4817-8873-99cad5b9c2b8",
+            "format": "5b3060f7-97c6-439f-8474-b885f2132ba8",
+            "lastmodified": "2018-09-17T19:48:46.668Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": null,
+            "slug": "netscape-bookmark-file-format",
+            "pronom_id": "fmt/1132",
+            "description": "Netscape Bookmark File Format"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "5a33ba4c-4e51-4080-8ef7-878d3a52bc05",
+            "format": "978b0fb0-60eb-4c3a-9baa-ac01d519c41f",
+            "lastmodified": "2018-09-17T19:48:46.703Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": null,
+            "slug": "farbfeld",
+            "pronom_id": "fmt/1133",
+            "description": "Farbfeld"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "7b7b9364-100c-4615-87ba-24d78c160d4b",
+            "format": "5c0d5ec2-5a77-4df5-a948-9bbb3685c87d",
+            "lastmodified": "2018-09-17T19:48:46.750Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": "1.1",
+            "slug": "gpx-11",
+            "pronom_id": "fmt/1134",
+            "description": "GPX 1.1"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "03110040-b241-4f5c-b574-02760a858654",
+            "format": "3588c0d1-bde9-4e18-b690-b8dd5559b37e",
+            "lastmodified": "2018-09-17T19:48:46.787Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": "2",
+            "slug": "sqlite-database-2",
+            "pronom_id": "fmt/1135",
+            "description": "SQLite Database 2"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "5c043139-37ef-4bf6-82fc-ae84ef79339c",
+            "format": "eb7a5a58-8909-4510-84c8-11cdd1d0ddf5",
+            "lastmodified": "2018-09-17T19:48:46.833Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": "6",
+            "slug": "minicad-6",
+            "pronom_id": "fmt/1136",
+            "description": "MiniCAD 6"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "fd41ef7c-7d07-4a0a-a1da-dda83df4f198",
+            "format": "eb7a5a58-8909-4510-84c8-11cdd1d0ddf5",
+            "lastmodified": "2018-09-17T19:48:46.866Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": "7",
+            "slug": "minicad-7",
+            "pronom_id": "fmt/1137",
+            "description": "MiniCAD 7"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "1e583e73-ac0a-4c8c-b166-37614d09231e",
+            "format": "2df75fa9-f215-4183-95c2-82a91d62342b",
+            "lastmodified": "2018-09-17T19:48:46.927Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": "8",
+            "slug": "minicadvectorworks-8",
+            "pronom_id": "fmt/1138",
+            "description": "MiniCAD/VectorWorks 8"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "5383f1a5-6135-486c-9028-c4cbcf46b427",
+            "format": "adac767d-00e6-48f9-ae3b-50408b90c03b",
+            "lastmodified": "2018-09-17T19:48:46.963Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": "9",
+            "slug": "vectorworks-9",
+            "pronom_id": "fmt/1139",
+            "description": "VectorWorks 9"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "559d5544-5c2c-4c84-9d1f-e2dcb482565a",
+            "format": "adac767d-00e6-48f9-ae3b-50408b90c03b",
+            "lastmodified": "2018-09-17T19:48:46.999Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": "10",
+            "slug": "vectorworks-10",
+            "pronom_id": "fmt/1140",
+            "description": "VectorWorks 10"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "26c434fd-10df-4b4b-9e4d-6a33d6a03ffc",
+            "format": "adac767d-00e6-48f9-ae3b-50408b90c03b",
+            "lastmodified": "2018-09-17T19:48:47.033Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": "11",
+            "slug": "vectorworks-11",
+            "pronom_id": "fmt/1141",
+            "description": "VectorWorks 11"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "2339cdab-ef58-482f-a46d-8550efab1e05",
+            "format": "dc61a606-ed49-435f-8828-f83a63e34824",
+            "lastmodified": "2018-09-17T19:48:47.084Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": null,
+            "slug": "vectorworks-plugin-or-script",
+            "pronom_id": "fmt/1142",
+            "description": "VectorWorks Plugin or Script"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "4618aedd-732e-478e-b65d-a90dbae1adfb",
+            "format": "990c9c18-f817-42da-a0ee-83fce0241bff",
+            "lastmodified": "2018-09-17T19:48:47.132Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": null,
+            "slug": "zisraw-czi-file-format",
+            "pronom_id": "fmt/1143",
+            "description": "ZISRAW (CZI) File Format"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "43de1cfa-36af-40df-aaff-20eeaf69280e",
+            "format": "0a3e9e20-1a0f-45cc-ada4-53fed9696079",
+            "lastmodified": "2018-09-17T19:48:47.181Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": null,
+            "slug": "compuserve-wincim",
+            "pronom_id": "fmt/1144",
+            "description": "CompuServe WinCIM"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "de0831f7-989d-445e-8140-461a1bd1768f",
+            "format": "9ec25ef4-0123-40dd-aa50-dde40e159922",
+            "lastmodified": "2018-09-17T19:48:47.229Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": null,
+            "slug": "maxwell-render-material-file",
+            "pronom_id": "fmt/1145",
+            "description": "Maxwell Render Material File"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "f13185bd-9e42-4ecd-abc9-6780b0c2a3d6",
+            "format": "1d8c2214-3490-44a6-85a8-e8e9ec3aab62",
+            "lastmodified": "2018-09-17T19:48:47.278Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": null,
+            "slug": "maxwell-render-image-format",
+            "pronom_id": "fmt/1146",
+            "description": "Maxwell Render Image Format"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "6ea2e909-8173-4d29-bd6d-b7df309d8e3b",
+            "format": "7cfae2d1-3eb4-4c3c-9469-5b9fd68c0b40",
+            "lastmodified": "2018-09-17T19:48:47.326Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": null,
+            "slug": "sidoun-winava-format",
+            "pronom_id": "fmt/1148",
+            "description": "SIDOUN WinAVA Format"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "dcdd0cdf-b9dd-4411-9ea1-bfcc809a2126",
+            "format": "4077db50-39a3-4428-b5f0-d532e28917ce",
+            "lastmodified": "2018-09-17T19:48:47.377Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": null,
+            "slug": "maxwell-render-scene-file-format",
+            "pronom_id": "fmt/1147",
+            "description": "Maxwell Render Scene File Format"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "e72477b4-bba4-4c28-9c0f-b3a96fbe0020",
+            "format": "ba07114c-fe3b-4fcf-a6e5-650a896453ea",
+            "lastmodified": "2018-09-17T19:48:47.421Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": null,
+            "slug": "markdown",
+            "pronom_id": "fmt/1149",
+            "description": "Markdown"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "86d509af-a3a0-4001-9a9b-87f419edc22a",
+            "format": "38ca6c74-52b5-45fc-8589-09fd158d68d9",
+            "lastmodified": "2018-09-17T19:48:47.461Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": null,
+            "slug": "4x-movie-file",
+            "pronom_id": "fmt/1150",
+            "description": "4X Movie File"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "052b38b6-4618-4b7f-825c-1928b96129d0",
+            "format": "2393e5f4-901d-4745-a0b8-470afa63ef39",
+            "lastmodified": "2018-09-17T19:48:47.516Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": "1",
+            "slug": "lightwright-1",
+            "pronom_id": "fmt/1151",
+            "description": "Lightwright 1"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "244644d0-af6d-4892-ae5d-a92c39d1bc75",
+            "format": "2393e5f4-901d-4745-a0b8-470afa63ef39",
+            "lastmodified": "2018-09-17T19:48:47.553Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": "2",
+            "slug": "lightwright-2",
+            "pronom_id": "fmt/1152",
+            "description": "Lightwright 2"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "4ee1b73b-6133-45b7-879f-52daa2e8e708",
+            "format": "2393e5f4-901d-4745-a0b8-470afa63ef39",
+            "lastmodified": "2018-09-17T19:48:47.588Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": "3",
+            "slug": "lightwright-3",
+            "pronom_id": "fmt/1153",
+            "description": "Lightwright 3"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "d3d05dd3-a109-44e4-aed0-6379865ebed0",
+            "format": "2393e5f4-901d-4745-a0b8-470afa63ef39",
+            "lastmodified": "2018-09-17T19:48:47.623Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": "4",
+            "slug": "lightwright-4",
+            "pronom_id": "fmt/1154",
+            "description": "Lightwright 4"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "b84f9257-3390-4c29-bbf3-501f6f292b7c",
+            "format": "2393e5f4-901d-4745-a0b8-470afa63ef39",
+            "lastmodified": "2018-09-17T19:48:47.657Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": "5",
+            "slug": "lightwright-5",
+            "pronom_id": "fmt/1155",
+            "description": "Lightwright 5"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "f61396e2-0495-4220-8e84-ba8de54475a9",
+            "format": "2393e5f4-901d-4745-a0b8-470afa63ef39",
+            "lastmodified": "2018-09-17T19:48:47.693Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": "6",
+            "slug": "lightwright-6",
+            "pronom_id": "fmt/1156",
+            "description": "Lightwright 6"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "9dd4067a-af18-4175-86b7-d985c9bd8179",
+            "format": "7f23c084-855a-42e9-a1d2-741753f8b9f1",
+            "lastmodified": "2018-09-17T19:48:47.744Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": "2",
+            "slug": "folio-nfo-v2",
+            "pronom_id": "fmt/1157",
+            "description": "Folio NFO v2"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "d1d67518-eb0b-4412-a29f-4a4a5db6aa68",
+            "format": "7f23c084-855a-42e9-a1d2-741753f8b9f1",
+            "lastmodified": "2018-09-17T19:48:47.778Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": "3",
+            "slug": "folio-nfo-v3",
+            "pronom_id": "fmt/1158",
+            "description": "Folio NFO v3"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "318dc9a3-21ce-4714-91a0-22dcc4e13301",
+            "format": "7f23c084-855a-42e9-a1d2-741753f8b9f1",
+            "lastmodified": "2018-09-17T19:48:47.814Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": "4",
+            "slug": "folio-nfo-v4",
+            "pronom_id": "fmt/1159",
+            "description": "Folio NFO v4"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "eeaff44e-e399-4a6e-807a-fb9e84087763",
+            "format": "ed81b563-77d4-41a0-8633-aaef3e2fc714",
+            "lastmodified": "2018-09-17T19:48:47.865Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": "3",
+            "slug": "folio-sdw-v3",
+            "pronom_id": "fmt/1160",
+            "description": "Folio SDW v3"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "b52d8c1c-4397-4b57-bbc7-6f2c5bffd505",
+            "format": "ed81b563-77d4-41a0-8633-aaef3e2fc714",
+            "lastmodified": "2018-09-17T19:48:47.902Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": "4",
+            "slug": "folio-sdw-v4",
+            "pronom_id": "fmt/1161",
+            "description": "Folio SDW v4"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "6de150ec-3389-4c69-8faa-600836941e99",
+            "format": "1076735d-77ac-4f84-b7ee-81d52bac90ed",
+            "lastmodified": "2018-09-17T19:48:47.950Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": null,
+            "slug": "folio-flat-file",
+            "pronom_id": "fmt/1162",
+            "description": "Folio Flat File"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "09333230-f525-4360-a5b7-c1435ec46902",
+            "format": "10bf0cb1-2135-4767-b564-5875d88dfe3d",
+            "lastmodified": "2018-09-17T19:48:47.999Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": null,
+            "slug": "folio-definition-file",
+            "pronom_id": "fmt/1163",
+            "description": "Folio Definition File"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "c528a1be-0cec-4ea2-9d53-cafb0c99dee1",
+            "format": "c244cf05-0e65-4aca-97c0-2c1c1c04baa5",
+            "lastmodified": "2018-09-17T19:48:48.038Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": null,
+            "slug": "praat-picture-file",
+            "pronom_id": "fmt/1164",
+            "description": "Praat Picture File"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "f7a47568-203e-4657-b109-db63c0823abc",
+            "format": "c58b339b-12ea-4bdd-9d40-2f593c5d01d2",
+            "lastmodified": "2018-09-17T19:48:48.075Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": null,
+            "slug": "praat-script-file",
+            "pronom_id": "fmt/1165",
+            "description": "Praat Script File"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "af54c897-aa92-451a-839c-bdaf1a4af5f0",
+            "format": "9e633418-8e77-40a9-94e0-7ae7f10ea802",
+            "lastmodified": "2018-09-17T19:48:48.115Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": null,
+            "slug": "niton-data-transfer",
+            "pronom_id": "fmt/1166",
+            "description": "Niton Data Transfer"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "2230192c-3cff-4077-925e-5ccd022d96b5",
+            "format": "b5f8fc88-fbac-4aa2-b0be-c6369392cd06",
+            "lastmodified": "2018-09-17T19:48:48.166Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": null,
+            "slug": "softimage-pic-format",
+            "pronom_id": "fmt/1167",
+            "description": "Softimage PIC Format"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "e4528d96-e236-49be-8994-df35514f2e2b",
+            "format": "43ca4a6c-af1b-4376-a637-919834fcaed0",
+            "lastmodified": "2018-09-17T19:48:48.216Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": null,
+            "slug": "maya-icons-or-swatches-file",
+            "pronom_id": "fmt/1168",
+            "description": "Maya Icons or Swatches file"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "f79b71de-b82c-429c-b881-36d17523b6e7",
+            "format": "844670f7-fde5-4a33-94df-c67177edef32",
+            "lastmodified": "2018-09-17T19:48:48.276Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": null,
+            "slug": "maya-iff",
+            "pronom_id": "fmt/1169",
+            "description": "Maya IFF"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "12992bf5-9dcc-4b3e-9333-ebd2c60698a1",
+            "format": "afdd61a4-406e-4ef6-8593-9065e8cf239a",
+            "lastmodified": "2018-09-17T19:48:48.329Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": "8.5",
+            "slug": "alias-studio-wire-85",
+            "pronom_id": "fmt/1170",
+            "description": "Alias Studio Wire 8.5"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "fcca2f89-9c36-41f0-955b-0cfb52dbf77a",
+            "format": "6fb8b85b-7826-4f1a-899a-e8f37145c63c",
+            "lastmodified": "2018-09-17T19:48:48.362Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": "9.0",
+            "slug": "alias-poweranimator-9",
+            "pronom_id": "fmt/1171",
+            "description": "Alias PowerAnimator 9"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "d8a561d4-d169-4400-ae24-90b906ffb117",
+            "format": "4ce64413-2a97-48cc-9a42-1e870f066421",
+            "lastmodified": "2018-09-17T19:48:48.385Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": "2.0",
+            "slug": "web-open-font-format-2",
+            "pronom_id": "fmt/1172",
+            "description": "Web Open Font Format 2"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "3dbe787b-e14e-47e7-873d-eca6ecaf08d3",
+            "format": "781f315e-cd6a-4d8e-a8ac-301b897fd954",
+            "lastmodified": "2018-09-17T19:48:48.429Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": null,
+            "slug": "framemd5",
+            "pronom_id": "fmt/1173",
+            "description": "FrameMD5"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "3a34729a-e5fe-4149-8e31-912b3294799d",
+            "format": "65efca5a-4482-47a2-8cc5-e0e98d932709",
+            "lastmodified": "2018-09-17T19:48:48.458Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": "2",
+            "slug": "hp-gl2",
+            "pronom_id": "fmt/1174",
+            "description": "HP-GL/2"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "9597da40-b647-456e-a12c-bd69eb6649d5",
+            "format": "afdd61a4-406e-4ef6-8593-9065e8cf239a",
+            "lastmodified": "2018-09-17T19:48:48.494Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": "9.0",
+            "slug": "alias-studio-wire-90",
+            "pronom_id": "fmt/1175",
+            "description": "Alias Studio Wire 9.0"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "5dbd5491-2100-4bd8-9916-d20f0c6c2084",
+            "format": "7269b84a-a5df-4b19-932e-e7e839b9d1d9",
+            "lastmodified": "2018-09-17T19:48:48.533Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": null,
+            "slug": "nullsoft-video-with-optional-header",
+            "pronom_id": "fmt/1176",
+            "description": "Nullsoft Video with optional header"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "55d0e293-7525-44ca-a83e-def8fa17d5d7",
+            "format": "46496986-d7a5-4671-b192-e2e08ab227e7",
+            "lastmodified": "2018-09-17T19:48:48.585Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": null,
+            "slug": "microstation-material-library",
+            "pronom_id": "fmt/1177",
+            "description": "Microstation Material Library"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "8c551f4b-6f81-48a1-b42d-3d8b7637bfe1",
+            "format": "e477b2c0-2a17-497c-864e-f6375fb76427",
+            "lastmodified": "2018-09-17T19:48:48.633Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": null,
+            "slug": "smaf",
+            "pronom_id": "fmt/1178",
+            "description": "SMAF"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "d6c33d0d-e4d4-4edc-baeb-08bfa52cb042",
+            "format": "a45ef95d-7c1e-40f0-aab4-20a1e268f5eb",
+            "lastmodified": "2018-09-17T19:48:48.682Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": "2.x",
+            "slug": "awd-2x",
+            "pronom_id": "fmt/1179",
+            "description": "AWD 2.x"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "f3ce9963-ac52-4025-82ec-2128617ea73e",
+            "format": "b72f6e08-b7b7-48cb-a922-f2de16da8fe8",
+            "lastmodified": "2018-09-17T19:48:48.719Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": "6+",
+            "slug": "cinema-4d-6",
+            "pronom_id": "fmt/1180",
+            "description": "Cinema 4D 6+"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "f9a5227a-1427-4f64-ad5b-4fb557f62b09",
+            "format": "1debc5fc-ed31-4bdc-8f39-b7b11d847c7f",
+            "lastmodified": "2018-09-17T19:48:48.764Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": null,
+            "slug": "bodypaint-3d",
+            "pronom_id": "fmt/1181",
+            "description": "BodyPaint 3D"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "41434872-15a8-4a8a-a914-e75e5d456a1e",
+            "format": "29853f2a-24d7-4306-93d9-e7eec3cf1a09",
+            "lastmodified": "2018-09-17T19:48:48.813Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": null,
+            "slug": "blitz3d",
+            "pronom_id": "fmt/1182",
+            "description": "Blitz3D"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "24566aa4-185b-4059-ac22-621788d57e46",
+            "format": "6e828574-c3a6-4c8b-a1e1-b6ef89919592",
+            "lastmodified": "2018-09-17T19:48:48.865Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": null,
+            "slug": "microstation-material-palette",
+            "pronom_id": "fmt/1183",
+            "description": "Microstation Material Palette"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "5707954f-8510-451b-a495-85683e3a0ca1",
+            "format": "6631c09c-0363-4f10-a65f-49f8bdbae658",
+            "lastmodified": "2018-09-17T19:48:48.915Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": null,
+            "slug": "indesign-markup-language-package",
+            "pronom_id": "fmt/1184",
+            "description": "InDesign Markup Language Package"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "403638e2-01c3-40b4-8f96-670b27b0be96",
+            "format": "bbf96270-946b-476a-9bea-164584eeea4c",
+            "lastmodified": "2018-09-17T19:48:48.964Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": null,
+            "slug": "apple-icon-image-format",
+            "pronom_id": "fmt/1185",
+            "description": "Apple Icon Image Format"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "4a187b64-eef8-4a75-8307-197bf20845de",
+            "format": "97bf687e-e984-428d-8367-23cc656b0470",
+            "lastmodified": "2018-09-17T19:48:49.013Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": null,
+            "slug": "dr-halo-image-palette",
+            "pronom_id": "fmt/1186",
+            "description": "Dr. Halo Image Palette"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "d9373b10-52f9-4c9d-b007-6c4fccf54568",
+            "format": "2b6660e8-22b0-4548-b234-683848e5a8c5",
+            "lastmodified": "2018-09-17T19:48:49.059Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": null,
+            "slug": "iwork13-template",
+            "pronom_id": "fmt/1187",
+            "description": "iWork13 Template"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "0f41faf5-38de-4c38-93c9-46afa392de5f",
+            "format": "c73d8d8e-a021-4925-850b-b70ae51e53ef",
+            "lastmodified": "2018-09-17T19:48:49.110Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": null,
+            "slug": "ogre-mesh-1x",
+            "pronom_id": "fmt/1188",
+            "description": "Ogre Mesh 1.x"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "931c6589-a581-42ab-a7af-ae7639fb1c22",
+            "format": "ed385839-0f26-40ba-badb-3595692dc766",
+            "lastmodified": "2018-09-17T19:48:49.162Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": null,
+            "slug": "ogre-mesh-xml",
+            "pronom_id": "fmt/1189",
+            "description": "Ogre Mesh XML"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "44eda455-114c-44fb-9329-4a73384cb854",
+            "format": "f689631e-c032-4de5-a412-31a221e9fdc9",
+            "lastmodified": "2018-09-17T19:48:49.211Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": null,
+            "slug": "adobe-swc-package",
+            "pronom_id": "fmt/1190",
+            "description": "Adobe SWC Package"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "b8ccd2ef-dcce-44a7-bea2-d520d1eccfa5",
+            "format": "f133eeaf-fb8a-4eb6-b710-033dc3c804e7",
+            "lastmodified": "2018-09-17T19:48:49.263Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": null,
+            "slug": "adobe-indesign-book",
+            "pronom_id": "fmt/1191",
+            "description": "Adobe InDesign Book"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "bbc94f83-b7cc-4aa5-8f6a-91067830a0af",
+            "format": "5c6e0640-4290-435c-8ef2-ccaba6f28ac0",
+            "lastmodified": "2018-09-17T19:48:49.313Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": null,
+            "slug": "adobe-indesign-library",
+            "pronom_id": "fmt/1192",
+            "description": "Adobe InDesign Library"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "698426b7-1607-4109-b964-d996ef00a65a",
+            "format": "e312bcbc-6a87-4b04-9b61-bc80880a5602",
+            "lastmodified": "2018-09-17T19:48:49.362Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": "1",
+            "slug": "zmodeler-z3d-v1",
+            "pronom_id": "fmt/1193",
+            "description": "ZModeler Z3D v1"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "7137b319-aff8-4530-a374-9e5b53b0874f",
+            "format": "e312bcbc-6a87-4b04-9b61-bc80880a5602",
+            "lastmodified": "2018-09-17T19:48:49.396Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": "2",
+            "slug": "zmodeler-z3d-v2",
+            "pronom_id": "fmt/1194",
+            "description": "ZModeler Z3D v2"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "6ad3c55b-63c0-43fe-8b00-69c2e7894ec9",
+            "format": "e312bcbc-6a87-4b04-9b61-bc80880a5602",
+            "lastmodified": "2018-09-17T19:48:49.431Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": "3",
+            "slug": "zmodeler-z3d-v3",
+            "pronom_id": "fmt/1195",
+            "description": "ZModeler Z3D v3"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "4fab1761-0884-4edc-8e4b-d204c93f5fe1",
+            "format": "c1f2a84f-fd6b-40de-8d7c-dd2bae449232",
+            "lastmodified": "2018-09-17T19:48:49.460Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": "2.1",
+            "slug": "siard-software-independent-archiving-of-relation-2",
+            "pronom_id": "fmt/1196",
+            "description": "SIARD (Software-Independent Archiving of Relational Databases)"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "0fc66c29-f8b6-4c91-9252-62a0a48c32b3",
+            "format": "a371e779-774d-49cb-be8e-84824ebcb9c3",
+            "lastmodified": "2018-09-17T19:48:49.505Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": null,
+            "slug": "myisam-indexes-file",
+            "pronom_id": "fmt/1197",
+            "description": "MyISAM Indexes File"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "5f6b17b5-dd10-4efe-a833-d18d926da878",
+            "format": "8030524e-c0fc-4c84-b68e-1399909c0d7c",
+            "lastmodified": "2018-09-17T19:48:49.551Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": "Binary",
+            "slug": "rdata-binary",
+            "pronom_id": "fmt/1198",
+            "description": "RData Binary"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "13692e0a-0d00-456c-be18-aa0e55bfaed4",
+            "format": "8030524e-c0fc-4c84-b68e-1399909c0d7c",
+            "lastmodified": "2018-09-17T19:48:49.580Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": "ASCII",
+            "slug": "rdata-ascii",
+            "pronom_id": "fmt/1199",
+            "description": "RData ASCII"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "c18baf74-e9fe-40ab-b6f8-53e9c04fca6e",
+            "format": "e1a0ebc4-c771-4ddc-ba7a-6195d617be0a",
+            "lastmodified": "2018-09-17T19:48:49.626Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": "6",
+            "slug": "powerdraw",
+            "pronom_id": "fmt/1200",
+            "description": "PowerDraw"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "c1f34f1f-fb6a-4cb7-90b9-1bfda1e4ae86",
+            "format": "d75fdc87-7cb9-40c8-88eb-e0bb729efb5e",
+            "lastmodified": "2018-09-17T19:48:49.661Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": null,
+            "slug": "powercadd",
+            "pronom_id": "fmt/1201",
+            "description": "PowerCADD"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "29a5c2a1-4a52-41a7-abde-42ccd59c5a4c",
+            "format": "b13b0930-0c1d-48a8-b6b1-0e97c68b0f36",
+            "lastmodified": "2018-09-17T19:48:49.700Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": null,
+            "slug": "guymager-acquisition-info-file",
+            "pronom_id": "fmt/1202",
+            "description": "Guymager Acquisition Info File"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "2bd1fbe0-79f9-4d19-8fa5-86b027e6261e",
+            "format": "8878c629-2c22-44a0-ab2e-03c4addaf178",
+            "lastmodified": "2018-09-17T19:48:49.736Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": "0",
+            "slug": "3dmf-binary-0",
+            "pronom_id": "fmt/1203",
+            "description": "3DMF Binary 0"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "326815d2-797e-4b03-8650-3a4cf6e2f91e",
+            "format": "7d0104af-3e60-4810-81d6-35814301d230",
+            "lastmodified": "2018-09-17T19:48:49.782Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": null,
+            "slug": "stratapro-vis",
+            "pronom_id": "fmt/1204",
+            "description": "StrataPro Vis"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "80801d93-cd1f-48f7-b16e-47a5ade35fa9",
+            "format": "3e96362a-3231-46fc-99e0-51c4de245a38",
+            "lastmodified": "2018-09-17T19:48:49.813Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": null,
+            "slug": "lightwave-3d-object",
+            "pronom_id": "fmt/1205",
+            "description": "Lightwave 3D Object"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "8a07a634-2341-481e-8776-cdda0136842a",
+            "format": "2705a991-d26b-4baa-b056-16fcc5ec21f2",
+            "lastmodified": "2018-09-17T19:48:49.864Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": null,
+            "slug": "impulse-tddd",
+            "pronom_id": "fmt/1206",
+            "description": "Impulse TDDD"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "5990c347-fcea-445d-956f-df710adbb08f",
+            "format": "ef201044-29e4-435e-ae02-bc618ab17c6c",
+            "lastmodified": "2018-09-17T19:48:49.910Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": null,
+            "slug": "sony-sfk-file",
+            "pronom_id": "fmt/1207",
+            "description": "Sony SFK file"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "b1777c2a-33c6-4be9-a889-6795ac063584",
+            "format": "22e69086-5e82-4a29-9729-7842a45b633f",
+            "lastmodified": "2018-09-17T19:48:49.964Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": null,
+            "slug": "virtools-file-format",
+            "pronom_id": "fmt/1208",
+            "description": "Virtools File Format"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "af12b9a8-f716-4fd4-a08a-f78842aeaa5b",
+            "format": "e9891d02-e8a8-487d-a9c2-a67cc59006a5",
+            "lastmodified": "2018-09-17T19:48:50.012Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": null,
+            "slug": "collada-dae",
+            "pronom_id": "fmt/1209",
+            "description": "COLLADA DAE"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "6029d42e-4a8a-40aa-8128-1e6d1d684aa7",
+            "format": "d30ae8db-1264-4741-9870-8af721304aca",
+            "lastmodified": "2018-09-17T19:48:50.063Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": null,
+            "slug": "wavefront-obj-polygonal-geometry",
+            "pronom_id": "fmt/1210",
+            "description": "Wavefront OBJ Polygonal Geometry"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "d9ef5868-916b-4a50-89a0-a58330cafdbc",
+            "format": "d03549ac-9297-4573-afd1-092273ea2414",
+            "lastmodified": "2018-09-17T19:48:50.113Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": null,
+            "slug": "wavefront-material-template-library",
+            "pronom_id": "fmt/1211",
+            "description": "Wavefront Material Template Library"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "2260d60d-8131-49ed-8769-00812f935978",
+            "format": "21d2a24c-6638-4add-96ff-8dbbf47a44a7",
+            "lastmodified": "2018-09-17T19:48:50.163Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": null,
+            "slug": "hp-ssm-cva",
+            "pronom_id": "fmt/1212",
+            "description": "HP SSM CVA"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "56447adf-0477-4a21-8d32-1b25981f5455",
+            "format": "c768ff66-b7fc-4c0b-a20c-37329576b804",
+            "lastmodified": "2018-09-17T19:48:50.212Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": "2",
+            "slug": "zoner-callisto-metafile",
+            "pronom_id": "fmt/1213",
+            "description": "Zoner Callisto Metafile"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "116c78a1-f0c6-4049-b4b9-4ffb32ac2875",
+            "format": "917e41f3-de98-4908-905c-2a7558af0d22",
+            "lastmodified": "2018-09-17T19:48:50.263Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": null,
+            "slug": "cakewalk-wrk-project",
+            "pronom_id": "fmt/1214",
+            "description": "Cakewalk WRK Project"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "95bba44f-f962-44be-b50f-3db27e9e26d2",
+            "format": "a220abd2-34b9-401a-8289-c6e740d91940",
+            "lastmodified": "2018-09-17T19:48:50.313Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": null,
+            "slug": "erdas-hfa",
+            "pronom_id": "fmt/1215",
+            "description": "ERDAS HFA"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "8e01fd9b-ab61-4bcb-8c0f-90e2df9c1eea",
+            "format": "82365ae6-180a-4ae1-bb06-127eafa38237",
+            "lastmodified": "2018-09-17T19:48:50.369Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": null,
+            "slug": "lotus-freelance-show",
+            "pronom_id": "fmt/1216",
+            "description": "Lotus Freelance Show"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "a848ca4d-8b70-4945-b7e4-7a41a55773ae",
+            "format": "f715eeb3-2de4-4032-a7eb-0c64dcbb9796",
+            "lastmodified": "2018-09-17T19:48:50.413Z",
+            "enabled": true,
+            "access_format": false,
+            "preservation_format": false,
+            "version": null,
+            "slug": "leonardo-image-format",
+            "pronom_id": "fmt/1217",
+            "description": "Leonardo Image Format"
+        },
+        "model": "fpr.formatversion"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "88a13347-e2a9-4454-a164-fea73635dcfa",
+            "format": "5a33ba4c-4e51-4080-8ef7-878d3a52bc05",
+            "lastmodified": "2018-09-17T19:48:46.716Z",
+            "enabled": true,
+            "command_output": ".ff",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "2ff9ae56-47b4-42b8-8a00-9147f6cde30f",
+            "format": "2339cdab-ef58-482f-a46d-8550efab1e05",
+            "lastmodified": "2018-09-17T19:48:47.102Z",
+            "enabled": true,
+            "command_output": ".vso",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "8e72db65-cead-4439-b5b3-0deec7a40d8d",
+            "format": "4618aedd-732e-478e-b65d-a90dbae1adfb",
+            "lastmodified": "2018-09-17T19:48:47.149Z",
+            "enabled": true,
+            "command_output": ".czi",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "209575e2-7e7c-4b7e-89d4-ff861c303d1c",
+            "format": "43de1cfa-36af-40df-aaff-20eeaf69280e",
+            "lastmodified": "2018-09-17T19:48:47.198Z",
+            "enabled": true,
+            "command_output": ".plx",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "38e02ffa-6eb0-46e1-9eab-a51e8c207d79",
+            "format": "de0831f7-989d-445e-8140-461a1bd1768f",
+            "lastmodified": "2018-09-17T19:48:47.247Z",
+            "enabled": true,
+            "command_output": ".mxm",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "1916a023-48de-4cec-8923-559684164500",
+            "format": "f13185bd-9e42-4ecd-abc9-6780b0c2a3d6",
+            "lastmodified": "2018-09-17T19:48:47.296Z",
+            "enabled": true,
+            "command_output": ".mxi",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "ea710cf6-4492-420b-aa4a-49672857c1f8",
+            "format": "6ea2e909-8173-4d29-bd6d-b7df309d8e3b",
+            "lastmodified": "2018-09-17T19:48:47.345Z",
+            "enabled": true,
+            "command_output": ".swa",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "4757c38d-d7cc-4aaa-944f-587f1b31662b",
+            "format": "dcdd0cdf-b9dd-4411-9ea1-bfcc809a2126",
+            "lastmodified": "2018-09-17T19:48:47.395Z",
+            "enabled": true,
+            "command_output": ".mxs",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "57de373b-0fcd-4737-b4cc-61d8e6bd5f20",
+            "format": "e72477b4-bba4-4c28-9c0f-b3a96fbe0020",
+            "lastmodified": "2018-09-17T19:48:47.435Z",
+            "enabled": true,
+            "command_output": ".md",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "bc42db6e-ec77-4c8d-8cfb-2b099162e244",
+            "format": "86d509af-a3a0-4001-9a9b-87f419edc22a",
+            "lastmodified": "2018-09-17T19:48:47.481Z",
+            "enabled": true,
+            "command_output": ".4xm",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "94959179-36a6-45a8-a036-e6ef17a1ef68",
+            "format": "052b38b6-4618-4b7f-825c-1928b96129d0",
+            "lastmodified": "2018-09-17T19:48:47.537Z",
+            "enabled": true,
+            "command_output": ".lw1",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "2d23dac5-322a-4bd9-8b7b-b494f688ddd3",
+            "format": "244644d0-af6d-4892-ae5d-a92c39d1bc75",
+            "lastmodified": "2018-09-17T19:48:47.570Z",
+            "enabled": true,
+            "command_output": ".lw2",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "29e1984f-65b9-4cf2-a9fb-2ade1e9004d2",
+            "format": "4ee1b73b-6133-45b7-879f-52daa2e8e708",
+            "lastmodified": "2018-09-17T19:48:47.607Z",
+            "enabled": true,
+            "command_output": ".lw3",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "0c085c0a-d50e-4bc7-b8f7-70785bb75045",
+            "format": "d3d05dd3-a109-44e4-aed0-6379865ebed0",
+            "lastmodified": "2018-09-17T19:48:47.640Z",
+            "enabled": true,
+            "command_output": ".lw4",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "c417252b-3a75-48cb-94f9-1fd7e531468d",
+            "format": "b84f9257-3390-4c29-bbf3-501f6f292b7c",
+            "lastmodified": "2018-09-17T19:48:47.677Z",
+            "enabled": true,
+            "command_output": ".lw5",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "83382086-430c-4003-851d-2b75063ae78f",
+            "format": "f61396e2-0495-4220-8e84-ba8de54475a9",
+            "lastmodified": "2018-09-17T19:48:47.711Z",
+            "enabled": true,
+            "command_output": ".lw6",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "bd77a50e-09fa-47bf-868b-65626c37ee66",
+            "format": "318dc9a3-21ce-4714-91a0-22dcc4e13301",
+            "lastmodified": "2018-09-17T19:48:47.832Z",
+            "enabled": true,
+            "command_output": ".nfo",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "005c6718-5e15-404a-9380-d4a0edc34ad0",
+            "format": "b52d8c1c-4397-4b57-bbc7-6f2c5bffd505",
+            "lastmodified": "2018-09-17T19:48:47.919Z",
+            "enabled": true,
+            "command_output": ".sdw",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "f822c92e-58fc-4421-8f57-3c04bb2edba1",
+            "format": "6de150ec-3389-4c69-8faa-600836941e99",
+            "lastmodified": "2018-09-17T19:48:47.967Z",
+            "enabled": true,
+            "command_output": ".fff",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "7013397e-a469-4a33-a1a5-934bc74eeb70",
+            "format": "09333230-f525-4360-a5b7-c1435ec46902",
+            "lastmodified": "2018-09-17T19:48:48.014Z",
+            "enabled": true,
+            "command_output": ".def",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "42b8b35b-776d-46af-a61a-1bc8598580ee",
+            "format": "c528a1be-0cec-4ea2-9d53-cafb0c99dee1",
+            "lastmodified": "2018-09-17T19:48:48.051Z",
+            "enabled": true,
+            "command_output": ".prapic",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "47f5eb4a-31ca-4fee-9b58-fb1f0080b04b",
+            "format": "f7a47568-203e-4657-b109-db63c0823abc",
+            "lastmodified": "2018-09-17T19:48:48.088Z",
+            "enabled": true,
+            "command_output": ".praat",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "a996ffaf-8a77-4bb8-bc58-5f55e13fb069",
+            "format": "af54c897-aa92-451a-839c-bdaf1a4af5f0",
+            "lastmodified": "2018-09-17T19:48:48.133Z",
+            "enabled": true,
+            "command_output": ".ndt",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "f039e13d-c48f-46ff-a73a-e82483785e29",
+            "format": "e4528d96-e236-49be-8994-df35514f2e2b",
+            "lastmodified": "2018-09-17T19:48:48.245Z",
+            "enabled": true,
+            "command_output": ".icons",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "195cced4-15c4-4800-a9c9-d809ac443739",
+            "format": "d8a561d4-d169-4400-ae24-90b906ffb117",
+            "lastmodified": "2018-09-17T19:48:48.403Z",
+            "enabled": true,
+            "command_output": ".woff2",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "7279eb22-cf06-4b5c-9a27-d47e1db9c68d",
+            "format": "3dbe787b-e14e-47e7-873d-eca6ecaf08d3",
+            "lastmodified": "2018-09-17T19:48:48.442Z",
+            "enabled": true,
+            "command_output": ".framemd5",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "7b465be9-ae10-47fb-bbe2-e5c46d0e7b25",
+            "format": "3a34729a-e5fe-4149-8e31-912b3294799d",
+            "lastmodified": "2018-09-17T19:48:48.478Z",
+            "enabled": true,
+            "command_output": ".000",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "f57bd3c6-56e7-4b8d-898e-ca55c9510bba",
+            "format": "5dbd5491-2100-4bd8-9916-d20f0c6c2084",
+            "lastmodified": "2018-09-17T19:48:48.552Z",
+            "enabled": true,
+            "command_output": ".nsv",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "cc1ce836-578b-4257-af93-8420a15f4cea",
+            "format": "8c551f4b-6f81-48a1-b42d-3d8b7637bfe1",
+            "lastmodified": "2018-09-17T19:48:48.650Z",
+            "enabled": true,
+            "command_output": ".mmf",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "d8a641b8-8ab1-49d2-b4a1-90f8d2a9b702",
+            "format": "d6c33d0d-e4d4-4edc-baeb-08bfa52cb042",
+            "lastmodified": "2018-09-17T19:48:48.704Z",
+            "enabled": true,
+            "command_output": ".awd",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "b3a58046-30e8-4cae-a36f-d21d547a8356",
+            "format": "5707954f-8510-451b-a495-85683e3a0ca1",
+            "lastmodified": "2018-09-17T19:48:48.933Z",
+            "enabled": true,
+            "command_output": ".idml",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "5b7c582e-6398-4053-9a19-74ecb12199bc",
+            "format": "403638e2-01c3-40b4-8f96-670b27b0be96",
+            "lastmodified": "2018-09-17T19:48:48.981Z",
+            "enabled": true,
+            "command_output": ".icns",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "35a6bdb4-0e83-4325-a9b8-5d5c72d2c791",
+            "format": "4a187b64-eef8-4a75-8307-197bf20845de",
+            "lastmodified": "2018-09-17T19:48:49.027Z",
+            "enabled": true,
+            "command_output": ".pal",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "f25172a1-a792-4cbd-9e8c-9ebba20f37b0",
+            "format": "d9373b10-52f9-4c9d-b007-6c4fccf54568",
+            "lastmodified": "2018-09-17T19:48:49.077Z",
+            "enabled": true,
+            "command_output": ".template",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "73905b19-57dc-436e-ad78-78eb10833084",
+            "format": "0f41faf5-38de-4c38-93c9-46afa392de5f",
+            "lastmodified": "2018-09-17T19:48:49.128Z",
+            "enabled": true,
+            "command_output": ".mesh",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "0c51a77a-1c22-4107-b62c-98dc6ea55743",
+            "format": "44eda455-114c-44fb-9329-4a73384cb854",
+            "lastmodified": "2018-09-17T19:48:49.229Z",
+            "enabled": true,
+            "command_output": ".swc",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "dc5094bf-72b5-4e0d-b05f-afcc580c288a",
+            "format": "b8ccd2ef-dcce-44a7-bea2-d520d1eccfa5",
+            "lastmodified": "2018-09-17T19:48:49.281Z",
+            "enabled": true,
+            "command_output": ".indb",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "730cae18-772c-4866-9561-c60775e38431",
+            "format": "bbc94f83-b7cc-4aa5-8f6a-91067830a0af",
+            "lastmodified": "2018-09-17T19:48:49.331Z",
+            "enabled": true,
+            "command_output": ".indl",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "363e6637-b31b-4599-a4a3-6d2f80c1cd72",
+            "format": "6ad3c55b-63c0-43fe-8b00-69c2e7894ec9",
+            "lastmodified": "2018-09-17T19:48:49.447Z",
+            "enabled": true,
+            "command_output": ".z3d",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "2d75ef33-9f3c-446a-9c55-e0f16dbcb67e",
+            "format": "0fc66c29-f8b6-4c91-9252-62a0a48c32b3",
+            "lastmodified": "2018-09-17T19:48:49.522Z",
+            "enabled": true,
+            "command_output": ".myi",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "69d5f171-8923-4296-9566-cbcbcd069872",
+            "format": "29a5c2a1-4a52-41a7-abde-42ccd59c5a4c",
+            "lastmodified": "2018-09-17T19:48:49.719Z",
+            "enabled": true,
+            "command_output": ".info",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "316ba01b-c101-4918-95b0-7056feafef66",
+            "format": "2bd1fbe0-79f9-4d19-8fa5-86b027e6261e",
+            "lastmodified": "2018-09-17T19:48:49.753Z",
+            "enabled": true,
+            "command_output": ".3dmf",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "a72d39df-54b3-4f9f-98dc-d3cc493ed784",
+            "format": "80801d93-cd1f-48f7-b16e-47a5ade35fa9",
+            "lastmodified": "2018-09-17T19:48:49.832Z",
+            "enabled": true,
+            "command_output": ".lw",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "724aca0c-74ea-4308-b922-ba0dc3576056",
+            "format": "8a07a634-2341-481e-8776-cdda0136842a",
+            "lastmodified": "2018-09-17T19:48:49.880Z",
+            "enabled": true,
+            "command_output": ".iob",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "ab23596b-1f13-49da-b791-00c2c25c468c",
+            "format": "5990c347-fcea-445d-956f-df710adbb08f",
+            "lastmodified": "2018-09-17T19:48:49.929Z",
+            "enabled": true,
+            "command_output": ".sfk",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "9a2e104d-2c84-4c99-b52c-304ec3c67851",
+            "format": "b1777c2a-33c6-4be9-a889-6795ac063584",
+            "lastmodified": "2018-09-17T19:48:49.981Z",
+            "enabled": true,
+            "command_output": ".cmo",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "46b5bade-8c06-400a-8ef0-93da992925d7",
+            "format": "af12b9a8-f716-4fd4-a08a-f78842aeaa5b",
+            "lastmodified": "2018-09-17T19:48:50.031Z",
+            "enabled": true,
+            "command_output": ".dae",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "9442a961-5770-4a71-a470-8ca7c319225a",
+            "format": "6029d42e-4a8a-40aa-8128-1e6d1d684aa7",
+            "lastmodified": "2018-09-17T19:48:50.082Z",
+            "enabled": true,
+            "command_output": ".obj",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "5aa86a19-316e-4615-b84e-ab5dade0d2f5",
+            "format": "d9ef5868-916b-4a50-89a0-a58330cafdbc",
+            "lastmodified": "2018-09-17T19:48:50.132Z",
+            "enabled": true,
+            "command_output": ".mtl",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "b9424ad4-a088-4d5b-bb35-4060c48992ee",
+            "format": "2260d60d-8131-49ed-8769-00812f935978",
+            "lastmodified": "2018-09-17T19:48:50.181Z",
+            "enabled": true,
+            "command_output": ".cva",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "294782c2-6e19-4b54-8969-90b526a6d7aa",
+            "format": "56447adf-0477-4a21-8d32-1b25981f5455",
+            "lastmodified": "2018-09-17T19:48:50.231Z",
+            "enabled": true,
+            "command_output": ".f",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "e0aa2df3-b777-4597-8aef-5be130a7548c",
+            "format": "116c78a1-f0c6-4049-b4b9-4ffb32ac2875",
+            "lastmodified": "2018-09-17T19:48:50.281Z",
+            "enabled": true,
+            "command_output": ".wrk",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "7e88fab9-2b1c-403c-85e9-3302d00d9952",
+            "format": "8e01fd9b-ab61-4bcb-8c0f-90e2df9c1eea",
+            "lastmodified": "2018-09-17T19:48:50.386Z",
+            "enabled": true,
+            "command_output": ".prz",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    },
+    {
+        "fields": {
+            "replaces": null,
+            "uuid": "837bae33-de8c-447d-bac0-76c78c9b6b3f",
+            "format": "a848ca4d-8b70-4945-b7e4-7a41a55773ae",
+            "lastmodified": "2018-09-17T19:48:50.433Z",
+            "enabled": true,
+            "command_output": ".leo",
+            "command": "41efbe1b-3fc7-4b24-9290-d0fb5d0ea9e9"
+        },
+        "model": "fpr.idrule"
+    }
+]


### PR DESCRIPTION
Updates to latest PRONOM.

The scripts used to generate the previous migration and this migration have an issue with three file formats that are already in the system (the three are `x-fmt/395, fmt/1042, fmt/1083`) but get re-added with every script run. They were automatically added and manually removed from the pronom_94.json. I took them out of the pronom_93.json as well so migrations will remain clean going forward.

Maybe should be a separate commit, but... we can discuss. I'd be more concerned if the previous release had ever been used in production anywhere, but it hasn't!... or has it?