### PR TITLE
IDCommand: fix active filter

### DIFF
--- a/fpr/views.py
+++ b/fpr/views.py
@@ -322,8 +322,7 @@ def idrule_delete(request, uuid):
 
 
 def idcommand_list(request):
-    replacing_commands = [r[0] for r in fprmodels.IDCommand.objects.filter(replaces__isnull=False).values_list('replaces_id')]
-    idcommands = fprmodels.IDCommand.objects.exclude(uuid__in=replacing_commands)
+    idcommands = fprmodels.IDCommand.active.all()
     return render(request, 'fpr/idcommand/list.html', context(locals()))
 
 


### PR DESCRIPTION
Connects to https://github.com/archivematica/Issues/issues/212.

The problem is solved by only showing enabled elements. Is that enough? Do we have to list disabled elements that have no replacements too?

Before the fix:
![image](https://user-images.githubusercontent.com/606459/46113859-e83e6280-c1a4-11e8-9623-0fc73a64c542.png)

After the fix:
![image](https://user-images.githubusercontent.com/606459/46113884-0015e680-c1a5-11e8-95cf-685d21b2013b.png)
