### PR TITLE
Does not show alleged version of fptools

### DIFF
--- a/fpr/templates/fpr/fptool/detail.html
+++ b/fpr/templates/fpr/fptool/detail.html
@@ -1,13 +1,13 @@
 {% extends "fpr/app_layout.html" %}
 {% load i18n %}
 
-{% block title %}{{ block.super }} - {% blocktrans with description=fptool.description version=fptool.version %}Format policy registry tool {{ description }} {{ version }}{% endblocktrans %}{% endblock title %}
-{% block page_title %}{% blocktrans with description=fptool.description version=fptool.version %}Format policy registry tool {{ description }} {{ version }}{% endblocktrans %}{% endblock page_title %}
+{% block title %}{{ block.super }} - {% blocktrans with description=fptool.description  %}Format policy registry tool {{ description }} {% endblocktrans %}{% endblock title %}
+{% block page_title %}{% blocktrans with description=fptool.description  %}Format policy registry tool {{ description }} {% endblocktrans %}{% endblock page_title %}
 
 {% block breadcrumbs %}
 {{ block.super }}
 <li><a href="{% url 'fptool_list' %}">{% trans "Format policy registry tools" %}</a></li>
-<li>{{ fptool.description }} {{ fptool.version }}</li>
+<li>{{ fptool.description }}</li>
 {% endblock breadcrumbs %}
 
 {% block app_content %}
@@ -24,8 +24,6 @@
         <dd>{{ fptool.uuid }}</dd>
         <dt>{% trans "Description" %}</dt>
         <dd>{{ fptool.description }}</dd>
-        <dt>{% trans "Version" %}</dt>
-        <dd>{{ fptool.version }}</dd>
         <dt>{% trans "Enabled" %}</dt>
         <dd>{{ fptool.enabled|yesno:_('Yes,No') }}</dd>
         {% if request.user.is_superuser %}

--- a/fpr/templates/fpr/fptool/list.html
+++ b/fpr/templates/fpr/fptool/list.html
@@ -27,7 +27,6 @@
         <thead>
           <tr>
             <th>{% trans "Description" %}</th>
-            <th>{% trans "Version" %}</th>
             <th>{% trans "Actions" %}</th>
           </tr>
         </thead>
@@ -35,7 +34,6 @@
         {% for fptool in fptools %}
           <tr>
             <td><a href="{% url 'fptool_detail' fptool.slug %}">{{ fptool.description }}</a></td>
-            <td>{{ fptool.version }}</td>
             <td>
                <a href="{% url 'fptool_detail' fptool.slug %}">{% trans "View" %}</a>
                {% if request.user.is_superuser %}


### PR DESCRIPTION
Hides (often wrong) version of tool, as it depends on the system. This is connected to https://github.com/archivematica/Issues/issues/191.

Note: This deliberately leaves the IDTool versions in place, since those are updated along with PRONOM updates, and should always be accurate.